### PR TITLE
vendor sync-github-releases dependencies

### DIFF
--- a/cmd/sync-github-release/Godeps/Godeps.json
+++ b/cmd/sync-github-release/Godeps/Godeps.json
@@ -1,0 +1,27 @@
+{
+	"ImportPath": "github.com/tcnksm/misc/cmd/sync-github-release",
+	"GoVersion": "go1.8",
+	"GodepVersion": "v79",
+	"Deps": [
+		{
+			"ImportPath": "github.com/google/go-github/github",
+			"Rev": "a1746f282059a5d71c4d8a270753698e164151e5"
+		},
+		{
+			"ImportPath": "github.com/google/go-querystring/query",
+			"Rev": "9235644dd9e52eeae6fa48efd539fdc351a0af53"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "a6577fac2d73be281a500b310739095313165611"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "1e695b1c8febf17aad3bfa7bf0a819ef94b98ad5"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/internal",
+			"Rev": "1e695b1c8febf17aad3bfa7bf0a819ef94b98ad5"
+		}
+	]
+}

--- a/cmd/sync-github-release/Godeps/Readme
+++ b/cmd/sync-github-release/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/AUTHORS
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/AUTHORS
@@ -1,0 +1,97 @@
+# This is the official list of go-github authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder. To see the full list
+# of contributors, see the revision history in source control or
+# https://github.com/google/go-github/graphs/contributors.
+#
+# Authors who wish to be recognized in this file should add themselves (or
+# their employer, as appropriate).
+
+Ainsley Chong <ainsley.chong@gmail.com>
+Akeda Bagus <akeda@x-team.com>
+Alec Thomas <alec@swapoff.org>
+Alexander Harkness <me@bearbin.net>
+Amey Sakhadeo <me@ameyms.com>
+Andreas Garnæs <https://github.com/andreas>
+Andrew Ryabchun <aryabchun@mail.ua>
+Arıl Bozoluk <arilbozoluk@hotmail.com>
+Austin Dizzy <dizzy@wow.com>
+Beshr Kayali <beshrkayali@gmail.com>
+Beyang Liu <beyang.liu@gmail.com>
+Björn Häuser <b.haeuser@rebuy.de>
+Brad Harris <bmharris@gmail.com>
+Brian Egizi <brian@mojotech.com>
+Cami Diez <diezcami@gmail.com>
+Carlos Alexandro Becker <caarlos0@gmail.com>
+Charlie Yan <charlieyan08@gmail.com>
+Chris Roche <chris@vsco.co>
+Chris Schaefer <chris@dtzq.com>
+Colin Misare <github.com/cmisare>
+Craig Peterson <cpeterson@stackoverflow.com>
+Cristian Maglie <c.maglie@bug.st>
+Daniel Leavitt <daniel.leavitt@gmail.com>
+Dave Henderson <dhenderson@gmail.com>
+Diego Lapiduz <diego.lapiduz@cfpb.gov>
+Dmitri Shuralyov <shurcooL@gmail.com>
+dmnlk <seikima2demon@gmail.com>
+Doug Turner <doug.turner@gmail.com>
+erwinvaneyk <erwinvaneyk@gmail.com>
+Filippo Valsorda <hi@filippo.io>
+Francis <hello@francismakes.com>
+Fredrik Jönsson <fredrik.jonsson@izettle.com>
+Garrett Squire <garrettsquire@gmail.com>
+Georgy Buranov <gburanov@gmail.com>
+Google Inc.
+griffin_stewie <panterathefamilyguy@gmail.com>
+Guz Alexander <kalimatas@gmail.com>
+Hanno Hecker <hanno.hecker@zalando.de>
+Hari haran <hariharan.uno@gmail.com>
+Huy Tr <kingbazoka@gmail.com>
+i2bskn <i2bskn@gmail.com>
+Isao Jonas <isao.jonas@gmail.com>
+Jameel Haffejee <RC1140@republiccommandos.co.za>
+Jihoon Chung <j.c@navercorp.com>
+John Engelman <john.r.engelman@gmail.com>
+Juan Basso <jrbasso@gmail.com>
+Julien Rostand <jrostand@users.noreply.github.com>
+Justin Abrahms <justin@abrah.ms>
+Konrad Malawski <konrad.malawski@project13.pl>
+Krzysztof Kowalczyk <kkowalczyk@gmail.com>
+kyokomi <kyoko1220adword@gmail.com>
+Luke Evers <me@lukevers.com>
+Luke Roberts <email@luke-roberts.co.uk>
+Maksim Zhylinski <uzzable@gmail.com>
+Martin-Louis Bright <mlbright@gmail.com>
+Mat Geist <matgeist@gmail.com>
+Matt Landis <landis.matt@gmail.com>
+Maxime Bury <maxime.bury@gmail.com>
+Michael Tiller <michael.tiller@gmail.com>
+Neil O'Toole <neilotoole@apache.org>
+Ondrej Kupka <ondra.cap@gmail.com>
+Panagiotis Moustafellos <pmoust@gmail.com>
+Parker Moore <parkrmoore@gmail.com>
+Pierre Carrier <pierre@meteor.com>
+Piotr Zurek <p.zurek@gmail.com>
+Quinn Slack <qslack@qslack.com>
+Rackspace US, Inc.
+Red Hat, Inc.
+Rob Figueiredo <robfig@yext.com>
+Ruben Vereecken <rubenvereecken@gmail.com>
+Ryan Lower <rpjlower@gmail.com>
+saisi <saisi@users.noreply.github.com>
+Sander van Harmelen <svanharmelen@schubergphilis.com>
+Sean Wang <sean@decrypted.org>
+Shawn Smith <shawnpsmith@gmail.com>
+sona-tar <sona.zip@gmail.com>
+SoundCloud, Ltd.
+Stian Eikeland <stian@eikeland.se>
+Thomas Bruyelle <thomas.bruyelle@gmail.com>
+Timothée Peignier <timothee.peignier@tryphon.org>
+Trey Tacon <ttacon@gmail.com>
+Victor Castell <victor@victorcastell.com>
+William Bailey <mail@williambailey.org.uk>
+Yann Malet <yann.malet@gmail.com>
+Yannick Utard <yannickutard@gmail.com>
+Yicheng Qin <qycqycqycqycqyc@gmail.com>
+Zach Latta <zach@zachlatta.com>

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/LICENSE
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/LICENSE
@@ -1,0 +1,341 @@
+Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------
+
+Some documentation is taken from the GitHub Developer site
+<http://developer.github.com/>, which is available under the following Creative
+Commons Attribution 3.0 License.  This applies only to the go-github source
+code and would not apply to any compiled binaries.
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+    other pre-existing works, such as a translation, adaptation,
+    derivative work, arrangement of music or other alterations of a
+    literary or artistic work, or phonogram or performance and includes
+    cinematographic adaptations or any other form in which the Work may be
+    recast, transformed, or adapted including in any form recognizably
+    derived from the original, except that a work that constitutes a
+    Collection will not be considered an Adaptation for the purpose of
+    this License. For the avoidance of doubt, where the Work is a musical
+    work, performance or phonogram, the synchronization of the Work in
+    timed-relation with a moving image ("synching") will be considered an
+    Adaptation for the purpose of this License.
+ b. "Collection" means a collection of literary or artistic works, such as
+    encyclopedias and anthologies, or performances, phonograms or
+    broadcasts, or other works or subject matter other than works listed
+    in Section 1(f) below, which, by reason of the selection and
+    arrangement of their contents, constitute intellectual creations, in
+    which the Work is included in its entirety in unmodified form along
+    with one or more other contributions, each constituting separate and
+    independent works in themselves, which together are assembled into a
+    collective whole. A work that constitutes a Collection will not be
+    considered an Adaptation (as defined above) for the purposes of this
+    License.
+ c. "Distribute" means to make available to the public the original and
+    copies of the Work or Adaptation, as appropriate, through sale or
+    other transfer of ownership.
+ d. "Licensor" means the individual, individuals, entity or entities that
+    offer(s) the Work under the terms of this License.
+ e. "Original Author" means, in the case of a literary or artistic work,
+    the individual, individuals, entity or entities who created the Work
+    or if no individual or entity can be identified, the publisher; and in
+    addition (i) in the case of a performance the actors, singers,
+    musicians, dancers, and other persons who act, sing, deliver, declaim,
+    play in, interpret or otherwise perform literary or artistic works or
+    expressions of folklore; (ii) in the case of a phonogram the producer
+    being the person or legal entity who first fixes the sounds of a
+    performance or other sounds; and, (iii) in the case of broadcasts, the
+    organization that transmits the broadcast.
+ f. "Work" means the literary and/or artistic work offered under the terms
+    of this License including without limitation any production in the
+    literary, scientific and artistic domain, whatever may be the mode or
+    form of its expression including digital form, such as a book,
+    pamphlet and other writing; a lecture, address, sermon or other work
+    of the same nature; a dramatic or dramatico-musical work; a
+    choreographic work or entertainment in dumb show; a musical
+    composition with or without words; a cinematographic work to which are
+    assimilated works expressed by a process analogous to cinematography;
+    a work of drawing, painting, architecture, sculpture, engraving or
+    lithography; a photographic work to which are assimilated works
+    expressed by a process analogous to photography; a work of applied
+    art; an illustration, map, plan, sketch or three-dimensional work
+    relative to geography, topography, architecture or science; a
+    performance; a broadcast; a phonogram; a compilation of data to the
+    extent it is protected as a copyrightable work; or a work performed by
+    a variety or circus performer to the extent it is not otherwise
+    considered a literary or artistic work.
+ g. "You" means an individual or entity exercising rights under this
+    License who has not previously violated the terms of this License with
+    respect to the Work, or who has received express permission from the
+    Licensor to exercise rights under this License despite a previous
+    violation.
+ h. "Publicly Perform" means to perform public recitations of the Work and
+    to communicate to the public those public recitations, by any means or
+    process, including by wire or wireless means or public digital
+    performances; to make available to the public Works in such a way that
+    members of the public may access these Works from a place and at a
+    place individually chosen by them; to perform the Work to the public
+    by any means or process and the communication to the public of the
+    performances of the Work, including by public digital performance; to
+    broadcast and rebroadcast the Work by any means including signs,
+    sounds or images.
+ i. "Reproduce" means to make copies of the Work by any means including
+    without limitation by sound or visual recordings and the right of
+    fixation and reproducing fixations of the Work, including storage of a
+    protected performance or phonogram in digital form or other electronic
+    medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+limit, or restrict any uses free from copyright or rights arising from
+limitations or exceptions that are provided for in connection with the
+copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:
+
+ a. to Reproduce the Work, to incorporate the Work into one or more
+    Collections, and to Reproduce the Work as incorporated in the
+    Collections;
+ b. to create and Reproduce Adaptations provided that any such Adaptation,
+    including any translation in any medium, takes reasonable steps to
+    clearly label, demarcate or otherwise identify that changes were made
+    to the original Work. For example, a translation could be marked "The
+    original work was translated from English to Spanish," or a
+    modification could indicate "The original work has been modified.";
+ c. to Distribute and Publicly Perform the Work including as incorporated
+    in Collections; and,
+ d. to Distribute and Publicly Perform Adaptations.
+ e. For the avoidance of doubt:
+
+     i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme cannot be waived, the Licensor
+        reserves the exclusive right to collect such royalties for any
+        exercise by You of the rights granted under this License;
+    ii. Waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme can be waived, the Licensor waives the
+        exclusive right to collect such royalties for any exercise by You
+        of the rights granted under this License; and,
+   iii. Voluntary License Schemes. The Licensor waives the right to
+        collect royalties, whether individually or, in the event that the
+        Licensor is a member of a collecting society that administers
+        voluntary licensing schemes, via that society, from any exercise
+        by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now
+known or hereafter devised. The above rights include the right to make
+such modifications as are technically necessary to exercise the rights in
+other media and formats. Subject to Section 8(f), all rights not expressly
+granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+ a. You may Distribute or Publicly Perform the Work only under the terms
+    of this License. You must include a copy of, or the Uniform Resource
+    Identifier (URI) for, this License with every copy of the Work You
+    Distribute or Publicly Perform. You may not offer or impose any terms
+    on the Work that restrict the terms of this License or the ability of
+    the recipient of the Work to exercise the rights granted to that
+    recipient under the terms of the License. You may not sublicense the
+    Work. You must keep intact all notices that refer to this License and
+    to the disclaimer of warranties with every copy of the Work You
+    Distribute or Publicly Perform. When You Distribute or Publicly
+    Perform the Work, You may not impose any effective technological
+    measures on the Work that restrict the ability of a recipient of the
+    Work from You to exercise the rights granted to that recipient under
+    the terms of the License. This Section 4(a) applies to the Work as
+    incorporated in a Collection, but this does not require the Collection
+    apart from the Work itself to be made subject to the terms of this
+    License. If You create a Collection, upon notice from any Licensor You
+    must, to the extent practicable, remove from the Collection any credit
+    as required by Section 4(b), as requested. If You create an
+    Adaptation, upon notice from any Licensor You must, to the extent
+    practicable, remove from the Adaptation any credit as required by
+    Section 4(b), as requested.
+ b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+    Collections, You must, unless a request has been made pursuant to
+    Section 4(a), keep intact all copyright notices for the Work and
+    provide, reasonable to the medium or means You are utilizing: (i) the
+    name of the Original Author (or pseudonym, if applicable) if supplied,
+    and/or if the Original Author and/or Licensor designate another party
+    or parties (e.g., a sponsor institute, publishing entity, journal) for
+    attribution ("Attribution Parties") in Licensor's copyright notice,
+    terms of service or by other reasonable means, the name of such party
+    or parties; (ii) the title of the Work if supplied; (iii) to the
+    extent reasonably practicable, the URI, if any, that Licensor
+    specifies to be associated with the Work, unless such URI does not
+    refer to the copyright notice or licensing information for the Work;
+    and (iv) , consistent with Section 3(b), in the case of an Adaptation,
+    a credit identifying the use of the Work in the Adaptation (e.g.,
+    "French translation of the Work by Original Author," or "Screenplay
+    based on original Work by Original Author"). The credit required by
+    this Section 4 (b) may be implemented in any reasonable manner;
+    provided, however, that in the case of a Adaptation or Collection, at
+    a minimum such credit will appear, if a credit for all contributing
+    authors of the Adaptation or Collection appears, then as part of these
+    credits and in a manner at least as prominent as the credits for the
+    other contributing authors. For the avoidance of doubt, You may only
+    use the credit required by this Section for the purpose of attribution
+    in the manner set out above and, by exercising Your rights under this
+    License, You may not implicitly or explicitly assert or imply any
+    connection with, sponsorship or endorsement by the Original Author,
+    Licensor and/or Attribution Parties, as appropriate, of You or Your
+    use of the Work, without the separate, express prior written
+    permission of the Original Author, Licensor and/or Attribution
+    Parties.
+ c. Except as otherwise agreed in writing by the Licensor or as may be
+    otherwise permitted by applicable law, if You Reproduce, Distribute or
+    Publicly Perform the Work either by itself or as part of any
+    Adaptations or Collections, You must not distort, mutilate, modify or
+    take other derogatory action in relation to the Work which would be
+    prejudicial to the Original Author's honor or reputation. Licensor
+    agrees that in those jurisdictions (e.g. Japan), in which any exercise
+    of the right granted in Section 3(b) of this License (the right to
+    make Adaptations) would be deemed to be a distortion, mutilation,
+    modification or other derogatory action prejudicial to the Original
+    Author's honor and reputation, the Licensor will waive or not assert,
+    as appropriate, this Section, to the fullest extent permitted by the
+    applicable national law, to enable You to reasonably exercise Your
+    right under Section 3(b) of this License (right to make Adaptations)
+    but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+ a. This License and the rights granted hereunder will terminate
+    automatically upon any breach by You of the terms of this License.
+    Individuals or entities who have received Adaptations or Collections
+    from You under this License, however, will not have their licenses
+    terminated provided such individuals or entities remain in full
+    compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+    survive any termination of this License.
+ b. Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the
+    Work under different license terms or to stop distributing the Work at
+    any time; provided, however that any such election will not serve to
+    withdraw this License (or any other license that has been, or is
+    required to be, granted under the terms of this License), and this
+    License will continue in full force and effect unless terminated as
+    stated above.
+
+8. Miscellaneous
+
+ a. Each time You Distribute or Publicly Perform the Work or a Collection,
+    the Licensor offers to the recipient a license to the Work on the same
+    terms and conditions as the license granted to You under this License.
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+    offers to the recipient a license to the original Work on the same
+    terms and conditions as the license granted to You under this License.
+ c. If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of
+    the remainder of the terms of this License, and without further action
+    by the parties to this agreement, such provision shall be reformed to
+    the minimum extent necessary to make such provision valid and
+    enforceable.
+ d. No term or provision of this License shall be deemed waived and no
+    breach consented to unless such waiver or consent shall be in writing
+    and signed by the party to be charged with such waiver or consent.
+ e. This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings,
+    agreements or representations with respect to the Work not specified
+    here. Licensor shall not be bound by any additional provisions that
+    may appear in any communication from You. This License may not be
+    modified without the mutual written agreement of the Licensor and You.
+ f. The rights granted under, and the subject matter referenced, in this
+    License were drafted utilizing the terminology of the Berne Convention
+    for the Protection of Literary and Artistic Works (as amended on
+    September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+    Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+    and the Universal Copyright Convention (as revised on July 24, 1971).
+    These rights and subject matter take effect in the relevant
+    jurisdiction in which the License terms are sought to be enforced
+    according to the corresponding provisions of the implementation of
+    those treaty provisions in the applicable national law. If the
+    standard suite of rights granted under applicable copyright law
+    includes additional rights not granted under this License, such
+    additional rights are deemed to be included in the License; this
+    License is not intended to restrict the license of any rights under
+    applicable law.
+
+
+Creative Commons Notice
+
+    Creative Commons is not a party to this License, and makes no warranty
+    whatsoever in connection with the Work. Creative Commons will not be
+    liable to You or any party on any legal theory for any damages
+    whatsoever, including without limitation any general, special,
+    incidental or consequential damages arising in connection to this
+    license. Notwithstanding the foregoing two (2) sentences, if Creative
+    Commons has expressly identified itself as the Licensor hereunder, it
+    shall have all rights and obligations of Licensor.
+
+    Except for the limited purpose of indicating to the public that the
+    Work is licensed under the CCPL, Creative Commons does not authorize
+    the use by either party of the trademark "Creative Commons" or any
+    related trademark or logo of Creative Commons without the prior
+    written consent of Creative Commons. Any permitted use will be in
+    compliance with Creative Commons' then-current trademark usage
+    guidelines, as may be published on its website or otherwise made
+    available upon request from time to time. For the avoidance of doubt,
+    this trademark restriction does not form part of this License.
+
+    Creative Commons may be contacted at http://creativecommons.org/.

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity.go
@@ -1,0 +1,67 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// ActivityService handles communication with the activity related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/
+type ActivityService service
+
+// FeedLink represents a link to a related resource.
+type FeedLink struct {
+	HRef *string `json:"href,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+// Feeds represents timeline resources in Atom format.
+type Feeds struct {
+	TimelineURL                 *string  `json:"timeline_url,omitempty"`
+	UserURL                     *string  `json:"user_url,omitempty"`
+	CurrentUserPublicURL        *string  `json:"current_user_public_url,omitempty"`
+	CurrentUserURL              *string  `json:"current_user_url,omitempty"`
+	CurrentUserActorURL         *string  `json:"current_user_actor_url,omitempty"`
+	CurrentUserOrganizationURL  *string  `json:"current_user_organization_url,omitempty"`
+	CurrentUserOrganizationURLs []string `json:"current_user_organization_urls,omitempty"`
+	Links                       *struct {
+		Timeline                 *FeedLink  `json:"timeline,omitempty"`
+		User                     *FeedLink  `json:"user,omitempty"`
+		CurrentUserPublic        *FeedLink  `json:"current_user_public,omitempty"`
+		CurrentUser              *FeedLink  `json:"current_user,omitempty"`
+		CurrentUserActor         *FeedLink  `json:"current_user_actor,omitempty"`
+		CurrentUserOrganization  *FeedLink  `json:"current_user_organization,omitempty"`
+		CurrentUserOrganizations []FeedLink `json:"current_user_organizations,omitempty"`
+	} `json:"_links,omitempty"`
+}
+
+// ListFeeds lists all the feeds available to the authenticated user.
+//
+// GitHub provides several timeline resources in Atom format:
+//     Timeline: The GitHub global public timeline
+//     User: The public timeline for any user, using URI template
+//     Current user public: The public timeline for the authenticated user
+//     Current user: The private timeline for the authenticated user
+//     Current user actor: The private timeline for activity created by the
+//         authenticated user
+//     Current user organizations: The private timeline for the organizations
+//         the authenticated user is a member of.
+//
+// Note: Private feeds are only returned when authenticating via Basic Auth
+// since current feed URIs use the older, non revocable auth tokens.
+func (s *ActivityService) ListFeeds() (*Feeds, *Response, error) {
+	req, err := s.client.NewRequest("GET", "feeds", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f := &Feeds{}
+	resp, err := s.client.Do(req, f)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return f, resp, nil
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_events.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_events.go
@@ -1,0 +1,291 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Event represents a GitHub event.
+type Event struct {
+	Type       *string          `json:"type,omitempty"`
+	Public     *bool            `json:"public"`
+	RawPayload *json.RawMessage `json:"payload,omitempty"`
+	Repo       *Repository      `json:"repo,omitempty"`
+	Actor      *User            `json:"actor,omitempty"`
+	Org        *Organization    `json:"org,omitempty"`
+	CreatedAt  *time.Time       `json:"created_at,omitempty"`
+	ID         *string          `json:"id,omitempty"`
+}
+
+func (e Event) String() string {
+	return Stringify(e)
+}
+
+// Payload returns the parsed event payload. For recognized event types,
+// a value of the corresponding struct type will be returned.
+func (e *Event) Payload() (payload interface{}) {
+	switch *e.Type {
+	case "CommitCommentEvent":
+		payload = &CommitCommentEvent{}
+	case "CreateEvent":
+		payload = &CreateEvent{}
+	case "DeleteEvent":
+		payload = &DeleteEvent{}
+	case "DeploymentEvent":
+		payload = &DeploymentEvent{}
+	case "DeploymentStatusEvent":
+		payload = &DeploymentStatusEvent{}
+	case "ForkEvent":
+		payload = &ForkEvent{}
+	case "GollumEvent":
+		payload = &GollumEvent{}
+	case "IntegrationInstallationEvent":
+		payload = &IntegrationInstallationEvent{}
+	case "IntegrationInstallationRepositoriesEvent":
+		payload = &IntegrationInstallationRepositoriesEvent{}
+	case "IssueActivityEvent":
+		payload = &IssueActivityEvent{}
+	case "IssueCommentEvent":
+		payload = &IssueCommentEvent{}
+	case "IssuesEvent":
+		payload = &IssuesEvent{}
+	case "MemberEvent":
+		payload = &MemberEvent{}
+	case "MembershipEvent":
+		payload = &MembershipEvent{}
+	case "PageBuildEvent":
+		payload = &PageBuildEvent{}
+	case "PublicEvent":
+		payload = &PublicEvent{}
+	case "PullRequestEvent":
+		payload = &PullRequestEvent{}
+	case "PullRequestReviewCommentEvent":
+		payload = &PullRequestReviewCommentEvent{}
+	case "PushEvent":
+		payload = &PushEvent{}
+	case "ReleaseEvent":
+		payload = &ReleaseEvent{}
+	case "RepositoryEvent":
+		payload = &RepositoryEvent{}
+	case "StatusEvent":
+		payload = &StatusEvent{}
+	case "TeamAddEvent":
+		payload = &TeamAddEvent{}
+	case "WatchEvent":
+		payload = &WatchEvent{}
+	}
+	if err := json.Unmarshal(*e.RawPayload, &payload); err != nil {
+		panic(err.Error())
+	}
+	return payload
+}
+
+// ListEvents drinks from the firehose of all public events across GitHub.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events
+func (s *ActivityService) ListEvents(opt *ListOptions) ([]*Event, *Response, error) {
+	u, err := addOptions("events", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListRepositoryEvents lists events for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-repository-events
+func (s *ActivityService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/events", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListIssueEventsForRepository lists issue events for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+func (s *ActivityService) ListIssueEventsForRepository(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListEventsForRepoNetwork lists public events for a network of repositories.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
+func (s *ActivityService) ListEventsForRepoNetwork(owner, repo string, opt *ListOptions) ([]*Event, *Response, error) {
+	u := fmt.Sprintf("networks/%v/%v/events", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListEventsForOrganization lists public events for an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
+func (s *ActivityService) ListEventsForOrganization(org string, opt *ListOptions) ([]*Event, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/events", org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListEventsPerformedByUser lists the events performed by a user. If publicOnly is
+// true, only public events will be returned.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
+func (s *ActivityService) ListEventsPerformedByUser(user string, publicOnly bool, opt *ListOptions) ([]*Event, *Response, error) {
+	var u string
+	if publicOnly {
+		u = fmt.Sprintf("users/%v/events/public", user)
+	} else {
+		u = fmt.Sprintf("users/%v/events", user)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListEventsReceivedByUser lists the events received by a user. If publicOnly is
+// true, only public events will be returned.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
+func (s *ActivityService) ListEventsReceivedByUser(user string, publicOnly bool, opt *ListOptions) ([]*Event, *Response, error) {
+	var u string
+	if publicOnly {
+		u = fmt.Sprintf("users/%v/received_events/public", user)
+	} else {
+		u = fmt.Sprintf("users/%v/received_events", user)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}
+
+// ListUserEventsForOrganization provides the user’s organization dashboard. You
+// must be authenticated as the user to view this.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/#list-events-for-an-organization
+func (s *ActivityService) ListUserEventsForOrganization(org, user string, opt *ListOptions) ([]*Event, *Response, error) {
+	u := fmt.Sprintf("users/%v/events/orgs/%v", user, org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	events := new([]*Event)
+	resp, err := s.client.Do(req, events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *events, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_notifications.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_notifications.go
@@ -1,0 +1,222 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// Notification identifies a GitHub notification for a user.
+type Notification struct {
+	ID         *string              `json:"id,omitempty"`
+	Repository *Repository          `json:"repository,omitempty"`
+	Subject    *NotificationSubject `json:"subject,omitempty"`
+
+	// Reason identifies the event that triggered the notification.
+	//
+	// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#notification-reasons
+	Reason *string `json:"reason,omitempty"`
+
+	Unread     *bool      `json:"unread,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+	LastReadAt *time.Time `json:"last_read_at,omitempty"`
+	URL        *string    `json:"url,omitempty"`
+}
+
+// NotificationSubject identifies the subject of a notification.
+type NotificationSubject struct {
+	Title            *string `json:"title,omitempty"`
+	URL              *string `json:"url,omitempty"`
+	LatestCommentURL *string `json:"latest_comment_url,omitempty"`
+	Type             *string `json:"type,omitempty"`
+}
+
+// NotificationListOptions specifies the optional parameters to the
+// ActivityService.ListNotifications method.
+type NotificationListOptions struct {
+	All           bool      `url:"all,omitempty"`
+	Participating bool      `url:"participating,omitempty"`
+	Since         time.Time `url:"since,omitempty"`
+	Before        time.Time `url:"before,omitempty"`
+
+	ListOptions
+}
+
+// ListNotifications lists all notifications for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications
+func (s *ActivityService) ListNotifications(opt *NotificationListOptions) ([]*Notification, *Response, error) {
+	u := fmt.Sprintf("notifications")
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var notifications []*Notification
+	resp, err := s.client.Do(req, &notifications)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return notifications, resp, err
+}
+
+// ListRepositoryNotifications lists all notifications in a given repository
+// for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
+func (s *ActivityService) ListRepositoryNotifications(owner, repo string, opt *NotificationListOptions) ([]*Notification, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var notifications []*Notification
+	resp, err := s.client.Do(req, &notifications)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return notifications, resp, err
+}
+
+type markReadOptions struct {
+	LastReadAt time.Time `json:"last_read_at,omitempty"`
+}
+
+// MarkNotificationsRead marks all notifications up to lastRead as read.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-as-read
+func (s *ActivityService) MarkNotificationsRead(lastRead time.Time) (*Response, error) {
+	opts := &markReadOptions{
+		LastReadAt: lastRead,
+	}
+	req, err := s.client.NewRequest("PUT", "notifications", opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// MarkRepositoryNotificationsRead marks all notifications up to lastRead in
+// the specified repository as read.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
+func (s *ActivityService) MarkRepositoryNotificationsRead(owner, repo string, lastRead time.Time) (*Response, error) {
+	opts := &markReadOptions{
+		LastReadAt: lastRead,
+	}
+	u := fmt.Sprintf("repos/%v/%v/notifications", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// GetThread gets the specified notification thread.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#view-a-single-thread
+func (s *ActivityService) GetThread(id string) (*Notification, *Response, error) {
+	u := fmt.Sprintf("notifications/threads/%v", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notification := new(Notification)
+	resp, err := s.client.Do(req, notification)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return notification, resp, err
+}
+
+// MarkThreadRead marks the specified thread as read.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
+func (s *ActivityService) MarkThreadRead(id string) (*Response, error) {
+	u := fmt.Sprintf("notifications/threads/%v", id)
+
+	req, err := s.client.NewRequest("PATCH", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// GetThreadSubscription checks to see if the authenticated user is subscribed
+// to a thread.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
+func (s *ActivityService) GetThreadSubscription(id string) (*Subscription, *Response, error) {
+	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sub := new(Subscription)
+	resp, err := s.client.Do(req, sub)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return sub, resp, err
+}
+
+// SetThreadSubscription sets the subscription for the specified thread for the
+// authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
+func (s *ActivityService) SetThreadSubscription(id string, subscription *Subscription) (*Subscription, *Response, error) {
+	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+
+	req, err := s.client.NewRequest("PUT", u, subscription)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sub := new(Subscription)
+	resp, err := s.client.Do(req, sub)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return sub, resp, err
+}
+
+// DeleteThreadSubscription deletes the subscription for the specified thread
+// for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
+func (s *ActivityService) DeleteThreadSubscription(id string) (*Response, error) {
+	u := fmt.Sprintf("notifications/threads/%v/subscription", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_star.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_star.go
@@ -1,0 +1,132 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// StarredRepository is returned by ListStarred.
+type StarredRepository struct {
+	StarredAt  *Timestamp  `json:"starred_at,omitempty"`
+	Repository *Repository `json:"repo,omitempty"`
+}
+
+// Stargazer represents a user that has starred a repository.
+type Stargazer struct {
+	StarredAt *Timestamp `json:"starred_at,omitempty"`
+	User      *User      `json:"user,omitempty"`
+}
+
+// ListStargazers lists people who have starred the specified repo.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/starring/#list-stargazers
+func (s *ActivityService) ListStargazers(owner, repo string, opt *ListOptions) ([]*Stargazer, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/stargazers", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeStarringPreview)
+
+	stargazers := new([]*Stargazer)
+	resp, err := s.client.Do(req, stargazers)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *stargazers, resp, err
+}
+
+// ActivityListStarredOptions specifies the optional parameters to the
+// ActivityService.ListStarred method.
+type ActivityListStarredOptions struct {
+	// How to sort the repository list.  Possible values are: created, updated,
+	// pushed, full_name.  Default is "full_name".
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort repositories.  Possible values are: asc, desc.
+	// Default is "asc" when sort is "full_name", otherwise default is "desc".
+	Direction string `url:"direction,omitempty"`
+
+	ListOptions
+}
+
+// ListStarred lists all the repos starred by a user.  Passing the empty string
+// will list the starred repositories for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/starring/#list-repositories-being-starred
+func (s *ActivityService) ListStarred(user string, opt *ActivityListStarredOptions) ([]*StarredRepository, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/starred", user)
+	} else {
+		u = "user/starred"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeStarringPreview)
+
+	repos := new([]*StarredRepository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// IsStarred checks if a repository is starred by authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/activity/starring/#check-if-you-are-starring-a-repository
+func (s *ActivityService) IsStarred(owner, repo string) (bool, *Response, error) {
+	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	starred, err := parseBoolResponse(err)
+	return starred, resp, err
+}
+
+// Star a repository as the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/activity/starring/#star-a-repository
+func (s *ActivityService) Star(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// Unstar a repository as the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/activity/starring/#unstar-a-repository
+func (s *ActivityService) Unstar(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("user/starred/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_watching.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/activity_watching.go
@@ -1,0 +1,136 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Subscription identifies a repository or thread subscription.
+type Subscription struct {
+	Subscribed *bool      `json:"subscribed,omitempty"`
+	Ignored    *bool      `json:"ignored,omitempty"`
+	Reason     *string    `json:"reason,omitempty"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	URL        *string    `json:"url,omitempty"`
+
+	// only populated for repository subscriptions
+	RepositoryURL *string `json:"repository_url,omitempty"`
+
+	// only populated for thread subscriptions
+	ThreadURL *string `json:"thread_url,omitempty"`
+}
+
+// ListWatchers lists watchers of a particular repo.
+//
+// GitHub API Docs: http://developer.github.com/v3/activity/watching/#list-watchers
+func (s *ActivityService) ListWatchers(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/subscribers", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	watchers := new([]*User)
+	resp, err := s.client.Do(req, watchers)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *watchers, resp, err
+}
+
+// ListWatched lists the repositories the specified user is watching.  Passing
+// the empty string will fetch watched repos for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
+func (s *ActivityService) ListWatched(user string, opt *ListOptions) ([]*Repository, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/subscriptions", user)
+	} else {
+		u = "user/subscriptions"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	watched := new([]*Repository)
+	resp, err := s.client.Do(req, watched)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *watched, resp, err
+}
+
+// GetRepositorySubscription returns the subscription for the specified
+// repository for the authenticated user.  If the authenticated user is not
+// watching the repository, a nil Subscription is returned.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
+func (s *ActivityService) GetRepositorySubscription(owner, repo string) (*Subscription, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sub := new(Subscription)
+	resp, err := s.client.Do(req, sub)
+	if err != nil {
+		// if it's just a 404, don't return that as an error
+		_, err = parseBoolResponse(err)
+		return nil, resp, err
+	}
+
+	return sub, resp, err
+}
+
+// SetRepositorySubscription sets the subscription for the specified repository
+// for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
+func (s *ActivityService) SetRepositorySubscription(owner, repo string, subscription *Subscription) (*Subscription, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+
+	req, err := s.client.NewRequest("PUT", u, subscription)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sub := new(Subscription)
+	resp, err := s.client.Do(req, sub)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return sub, resp, err
+}
+
+// DeleteRepositorySubscription deletes the subscription for the specified
+// repository for the authenticated user.
+//
+// GitHub API Docs: https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
+func (s *ActivityService) DeleteRepositorySubscription(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/subscription", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/authorizations.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/authorizations.go
@@ -1,0 +1,436 @@
+// Copyright 2015 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Scope models a GitHub authorization scope.
+//
+// GitHub API docs:https://developer.github.com/v3/oauth/#scopes
+type Scope string
+
+// This is the set of scopes for GitHub API V3
+const (
+	ScopeNone           Scope = "(no scope)" // REVISIT: is this actually returned, or just a documentation artifact?
+	ScopeUser           Scope = "user"
+	ScopeUserEmail      Scope = "user:email"
+	ScopeUserFollow     Scope = "user:follow"
+	ScopePublicRepo     Scope = "public_repo"
+	ScopeRepo           Scope = "repo"
+	ScopeRepoDeployment Scope = "repo_deployment"
+	ScopeRepoStatus     Scope = "repo:status"
+	ScopeDeleteRepo     Scope = "delete_repo"
+	ScopeNotifications  Scope = "notifications"
+	ScopeGist           Scope = "gist"
+	ScopeReadRepoHook   Scope = "read:repo_hook"
+	ScopeWriteRepoHook  Scope = "write:repo_hook"
+	ScopeAdminRepoHook  Scope = "admin:repo_hook"
+	ScopeAdminOrgHook   Scope = "admin:org_hook"
+	ScopeReadOrg        Scope = "read:org"
+	ScopeWriteOrg       Scope = "write:org"
+	ScopeAdminOrg       Scope = "admin:org"
+	ScopeReadPublicKey  Scope = "read:public_key"
+	ScopeWritePublicKey Scope = "write:public_key"
+	ScopeAdminPublicKey Scope = "admin:public_key"
+	ScopeReadGPGKey     Scope = "read:gpg_key"
+	ScopeWriteGPGKey    Scope = "write:gpg_key"
+	ScopeAdminGPGKey    Scope = "admin:gpg_key"
+)
+
+// AuthorizationsService handles communication with the authorization related
+// methods of the GitHub API.
+//
+// This service requires HTTP Basic Authentication; it cannot be accessed using
+// an OAuth token.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/
+type AuthorizationsService service
+
+// Authorization represents an individual GitHub authorization.
+type Authorization struct {
+	ID             *int              `json:"id,omitempty"`
+	URL            *string           `json:"url,omitempty"`
+	Scopes         []Scope           `json:"scopes,omitempty"`
+	Token          *string           `json:"token,omitempty"`
+	TokenLastEight *string           `json:"token_last_eight,omitempty"`
+	HashedToken    *string           `json:"hashed_token,omitempty"`
+	App            *AuthorizationApp `json:"app,omitempty"`
+	Note           *string           `json:"note,omitempty"`
+	NoteURL        *string           `json:"note_url,omitempty"`
+	UpdateAt       *Timestamp        `json:"updated_at,omitempty"`
+	CreatedAt      *Timestamp        `json:"created_at,omitempty"`
+	Fingerprint    *string           `json:"fingerprint,omitempty"`
+
+	// User is only populated by the Check and Reset methods.
+	User *User `json:"user,omitempty"`
+}
+
+func (a Authorization) String() string {
+	return Stringify(a)
+}
+
+// AuthorizationApp represents an individual GitHub app (in the context of authorization).
+type AuthorizationApp struct {
+	URL      *string `json:"url,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	ClientID *string `json:"client_id,omitempty"`
+}
+
+func (a AuthorizationApp) String() string {
+	return Stringify(a)
+}
+
+// Grant represents an OAuth application that has been granted access to an account.
+type Grant struct {
+	ID        *int              `json:"id,omitempty"`
+	URL       *string           `json:"url,omitempty"`
+	App       *AuthorizationApp `json:"app,omitempty"`
+	CreatedAt *Timestamp        `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp        `json:"updated_at,omitempty"`
+	Scopes    []string          `json:"scopes,omitempty"`
+}
+
+func (g Grant) String() string {
+	return Stringify(g)
+}
+
+// AuthorizationRequest represents a request to create an authorization.
+type AuthorizationRequest struct {
+	Scopes       []Scope `json:"scopes,omitempty"`
+	Note         *string `json:"note,omitempty"`
+	NoteURL      *string `json:"note_url,omitempty"`
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+	Fingerprint  *string `json:"fingerprint,omitempty"`
+}
+
+func (a AuthorizationRequest) String() string {
+	return Stringify(a)
+}
+
+// AuthorizationUpdateRequest represents a request to update an authorization.
+//
+// Note that for any one update, you must only provide one of the "scopes"
+// fields.  That is, you may provide only one of "Scopes", or "AddScopes", or
+// "RemoveScopes".
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
+type AuthorizationUpdateRequest struct {
+	Scopes       []string `json:"scopes,omitempty"`
+	AddScopes    []string `json:"add_scopes,omitempty"`
+	RemoveScopes []string `json:"remove_scopes,omitempty"`
+	Note         *string  `json:"note,omitempty"`
+	NoteURL      *string  `json:"note_url,omitempty"`
+	Fingerprint  *string  `json:"fingerprint,omitempty"`
+}
+
+func (a AuthorizationUpdateRequest) String() string {
+	return Stringify(a)
+}
+
+// List the authorizations for the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
+func (s *AuthorizationsService) List(opt *ListOptions) ([]*Authorization, *Response, error) {
+	u := "authorizations"
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	auths := new([]*Authorization)
+	resp, err := s.client.Do(req, auths)
+	if err != nil {
+		return nil, resp, err
+	}
+	return *auths, resp, err
+}
+
+// Get a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
+func (s *AuthorizationsService) Get(id int) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+	return a, resp, err
+}
+
+// Create a new authorization for the specified OAuth application.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+func (s *AuthorizationsService) Create(auth *AuthorizationRequest) (*Authorization, *Response, error) {
+	u := "authorizations"
+
+	req, err := s.client.NewRequest("POST", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+	return a, resp, err
+}
+
+// GetOrCreateForApp creates a new authorization for the specified OAuth
+// application, only if an authorization for that application doesn’t already
+// exist for the user.
+//
+// If a new token is created, the HTTP status code will be "201 Created", and
+// the returned Authorization.Token field will be populated. If an existing
+// token is returned, the status code will be "200 OK" and the
+// Authorization.Token field will be empty.
+//
+// clientID is the OAuth Client ID with which to create the token.
+//
+// GitHub API docs:
+// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
+// - https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint
+func (s *AuthorizationsService) GetOrCreateForApp(clientID string, auth *AuthorizationRequest) (*Authorization, *Response, error) {
+	var u string
+	if auth.Fingerprint == nil || *auth.Fingerprint == "" {
+		u = fmt.Sprintf("authorizations/clients/%v", clientID)
+	} else {
+		u = fmt.Sprintf("authorizations/clients/%v/%v", clientID, *auth.Fingerprint)
+	}
+
+	req, err := s.client.NewRequest("PUT", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Edit a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
+func (s *AuthorizationsService) Edit(id int, auth *AuthorizationUpdateRequest) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("PATCH", u, auth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Delete a single authorization.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization
+func (s *AuthorizationsService) Delete(id int) (*Response, error) {
+	u := fmt.Sprintf("authorizations/%d", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Check if an OAuth token is valid for a specific app.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// The returned Authorization.User field will be populated.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#check-an-authorization
+func (s *AuthorizationsService) Check(clientID string, token string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Reset is used to reset a valid OAuth token without end user involvement.
+// Applications must save the "token" property in the response, because changes
+// take effect immediately.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// The returned Authorization.User field will be populated.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization
+func (s *AuthorizationsService) Reset(clientID string, token string) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}
+
+// Revoke an authorization for an application.
+//
+// Note that this operation requires the use of BasicAuth, but where the
+// username is the OAuth application clientID, and the password is its
+// clientSecret. Invalid tokens will return a 404 Not Found.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application
+func (s *AuthorizationsService) Revoke(clientID string, token string) (*Response, error) {
+	u := fmt.Sprintf("applications/%v/tokens/%v", clientID, token)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListGrants lists the set of OAuth applications that have been granted
+// access to a user's account. This will return one entry for each application
+// that has been granted access to the account, regardless of the number of
+// tokens an application has generated for the user.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#list-your-grants
+func (s *AuthorizationsService) ListGrants() ([]*Grant, *Response, error) {
+	req, err := s.client.NewRequest("GET", "applications/grants", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOAuthGrantAuthorizationsPreview)
+
+	grants := []*Grant{}
+	resp, err := s.client.Do(req, &grants)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return grants, resp, err
+}
+
+// GetGrant gets a single OAuth application grant.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant
+func (s *AuthorizationsService) GetGrant(id int) (*Grant, *Response, error) {
+	u := fmt.Sprintf("applications/grants/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOAuthGrantAuthorizationsPreview)
+
+	grant := new(Grant)
+	resp, err := s.client.Do(req, grant)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return grant, resp, err
+}
+
+// DeleteGrant deletes an OAuth application grant. Deleting an application's
+// grant will also delete all OAuth tokens associated with the application for
+// the user.
+//
+// GitHub API docs: https://developer.github.com/v3/oauth_authorizations/#delete-a-grant
+func (s *AuthorizationsService) DeleteGrant(id int) (*Response, error) {
+	u := fmt.Sprintf("applications/grants/%d", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeOAuthGrantAuthorizationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// CreateImpersonation creates an impersonation OAuth token.
+//
+// This requires admin permissions. With the returned Authorization.Token
+// you can e.g. create or delete a user's public SSH key. NOTE: creating a
+// new token automatically revokes an existing one.
+//
+// GitHub API docs: https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token
+func (s *AuthorizationsService) CreateImpersonation(username string, authReq *AuthorizationRequest) (*Authorization, *Response, error) {
+	u := fmt.Sprintf("admin/users/%v/authorizations", username)
+	req, err := s.client.NewRequest("POST", u, authReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Authorization)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+	return a, resp, err
+}
+
+// DeleteImpersonation deletes an impersonation OAuth token.
+//
+// NOTE: there can be only one at a time.
+//
+// GitHub API docs: https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token
+func (s *AuthorizationsService) DeleteImpersonation(username string) (*Response, error) {
+	u := fmt.Sprintf("admin/users/%v/authorizations", username)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/doc.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/doc.go
@@ -1,0 +1,145 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package github provides a client for using the GitHub API.
+
+Usage:
+
+	import "github.com/google/go-github/github"
+
+Construct a new GitHub client, then use the various services on the client to
+access different parts of the GitHub API. For example:
+
+	client := github.NewClient(nil)
+
+	// list all organizations for user "willnorris"
+	orgs, _, err := client.Organizations.List("willnorris", nil)
+
+Some API methods have optional parameters that can be passed. For example:
+
+	client := github.NewClient(nil)
+
+	// list public repositories for org "github"
+	opt := &github.RepositoryListByOrgOptions{Type: "public"}
+	repos, _, err := client.Repositories.ListByOrg("github", opt)
+
+The services of a client divide the API into logical chunks and correspond to
+the structure of the GitHub API documentation at
+http://developer.github.com/v3/.
+
+Authentication
+
+The go-github library does not directly handle authentication. Instead, when
+creating a new client, pass an http.Client that can handle authentication for
+you. The easiest and recommended way to do this is using the golang.org/x/oauth2
+library, but you can always use any other library that provides an http.Client.
+If you have an OAuth2 access token (for example, a personal API token), you can
+use it with the oauth2 library using:
+
+	import "golang.org/x/oauth2"
+
+	func main() {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: "... your access token ..."},
+		)
+		tc := oauth2.NewClient(oauth2.NoContext, ts)
+
+		client := github.NewClient(tc)
+
+		// list all repositories for the authenticated user
+		repos, _, err := client.Repositories.List("", nil)
+	}
+
+Note that when using an authenticated Client, all calls made by the client will
+include the specified OAuth token. Therefore, authenticated clients should
+almost never be shared between different users.
+
+See the oauth2 docs for complete instructions on using that library.
+
+For API methods that require HTTP Basic Authentication, use the
+BasicAuthTransport.
+
+Rate Limiting
+
+GitHub imposes a rate limit on all API clients. Unauthenticated clients are
+limited to 60 requests per hour, while authenticated clients can make up to
+5,000 requests per hour. To receive the higher rate limit when making calls
+that are not issued on behalf of a user, use the
+UnauthenticatedRateLimitedTransport.
+
+The Rate method on a client returns the rate limit information based on the most
+recent API call. This is updated on every call, but may be out of date if it's
+been some time since the last API call and other clients have made subsequent
+requests since then. You can always call RateLimits() directly to get the most
+up-to-date rate limit data for the client.
+
+To detect an API rate limit error, you can check if its type is *github.RateLimitError:
+
+	repos, _, err := client.Repositories.List("", nil)
+	if _, ok := err.(*github.RateLimitError); ok {
+		log.Println("hit rate limit")
+	}
+
+Learn more about GitHub rate limiting at
+http://developer.github.com/v3/#rate-limiting.
+
+Conditional Requests
+
+The GitHub API has good support for conditional requests which will help
+prevent you from burning through your rate limit, as well as help speed up your
+application. go-github does not handle conditional requests directly, but is
+instead designed to work with a caching http.Transport. We recommend using
+https://github.com/gregjones/httpcache for that.
+
+Learn more about GitHub conditional requests at
+https://developer.github.com/v3/#conditional-requests.
+
+Creating and Updating Resources
+
+All structs for GitHub resources use pointer values for all non-repeated fields.
+This allows distinguishing between unset fields and those set to a zero-value.
+Helper functions have been provided to easily create these pointers for string,
+bool, and int values. For example:
+
+	// create a new private repository named "foo"
+	repo := &github.Repository{
+		Name:    github.String("foo"),
+		Private: github.Bool(true),
+	}
+	client.Repositories.Create("", repo)
+
+Users who have worked with protocol buffers should find this pattern familiar.
+
+Pagination
+
+All requests for resource collections (repos, pull requests, issues, etc.)
+support pagination. Pagination options are described in the
+github.ListOptions struct and passed to the list methods directly or as an
+embedded type of a more specific list options struct (for example
+github.PullRequestListOptions). Pages information is available via the
+github.Response struct.
+
+	client := github.NewClient(nil)
+
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{PerPage: 10},
+	}
+	// get all pages of results
+	var allRepos []*github.Repository
+	for {
+		repos, resp, err := client.Repositories.ListByOrg("github", opt)
+		if err != nil {
+			return err
+		}
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.ListOptions.Page = resp.NextPage
+	}
+
+*/
+package github

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/event_types.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/event_types.go
@@ -1,0 +1,502 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// These event types are shared between the Events API and used as Webhook payloads.
+
+package github
+
+// CommitCommentEvent is triggered when a commit comment is created.
+// The Webhook event name is "commit_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#commitcommentevent
+type CommitCommentEvent struct {
+	Comment *RepositoryComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Action *string     `json:"action,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// CreateEvent represents a created repository, branch, or tag.
+// The Webhook event name is "create".
+//
+// Note: webhooks will not receive this event for created repositories.
+// Additionally, webhooks will not receive this event for tags if more
+// than three tags are pushed at once.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#createevent
+type CreateEvent struct {
+	Ref *string `json:"ref,omitempty"`
+	// RefType is the object that was created. Possible values are: "repository", "branch", "tag".
+	RefType      *string `json:"ref_type,omitempty"`
+	MasterBranch *string `json:"master_branch,omitempty"`
+	Description  *string `json:"description,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	PusherType *string     `json:"pusher_type,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+	Sender     *User       `json:"sender,omitempty"`
+}
+
+// DeleteEvent represents a deleted branch or tag.
+// The Webhook event name is "delete".
+//
+// Note: webhooks will not receive this event for tags if more than three tags
+// are deleted at once.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deleteevent
+type DeleteEvent struct {
+	Ref *string `json:"ref,omitempty"`
+	// RefType is the object that was deleted. Possible values are: "branch", "tag".
+	RefType *string `json:"ref_type,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	PusherType *string     `json:"pusher_type,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+	Sender     *User       `json:"sender,omitempty"`
+}
+
+// DeploymentEvent represents a deployment.
+// The Webhook event name is "deployment".
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentevent
+type DeploymentEvent struct {
+	Deployment *Deployment `json:"deployment,omitempty"`
+	Repo       *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}
+
+// DeploymentStatusEvent represents a deployment status.
+// The Webhook event name is "deployment_status".
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#deploymentstatusevent
+type DeploymentStatusEvent struct {
+	Deployment       *Deployment       `json:"deployment,omitempty"`
+	DeploymentStatus *DeploymentStatus `json:"deployment_status,omitempty"`
+	Repo             *Repository       `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Sender *User `json:"sender,omitempty"`
+}
+
+// ForkEvent is triggered when a user forks a repository.
+// The Webhook event name is "fork".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#forkevent
+type ForkEvent struct {
+	// Forkee is the created repository.
+	Forkee *Repository `json:"forkee,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// Page represents a single Wiki page.
+type Page struct {
+	PageName *string `json:"page_name,omitempty"`
+	Title    *string `json:"title,omitempty"`
+	Summary  *string `json:"summary,omitempty"`
+	Action   *string `json:"action,omitempty"`
+	SHA      *string `json:"sha,omitempty"`
+	HTMLURL  *string `json:"html_url,omitempty"`
+}
+
+// GollumEvent is triggered when a Wiki page is created or updated.
+// The Webhook event name is "gollum".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#gollumevent
+type GollumEvent struct {
+	Pages []*Page `json:"pages,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// IssueActivityEvent represents the payload delivered by Issue webhook.
+//
+// Deprecated: Use IssuesEvent instead.
+type IssueActivityEvent struct {
+	Action *string `json:"action,omitempty"`
+	Issue  *Issue  `json:"issue,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// EditChange represents the changes when an issue, pull request, or comment has
+// been edited.
+type EditChange struct {
+	Title *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"title,omitempty"`
+	Body *struct {
+		From *string `json:"from,omitempty"`
+	} `json:"body,omitempty"`
+}
+
+// IntegrationInstallationEvent is triggered when an integration is created or deleted.
+// The Webhook event name is "integration_installation".
+//
+// GitHub docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationevent
+type IntegrationInstallationEvent struct {
+	// The action that was performed. Possible values for an "integration_installation"
+	// event are: "created", "deleted".
+	Action       *string       `json:"action,omitempty"`
+	Installation *Installation `json:"installation,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
+}
+
+// IntegrationInstallationRepositoriesEvent is triggered when an integration repository
+// is added or removed. The Webhook event name is "integration_installation_repositories".
+//
+// GitHub docs: https://developer.github.com/early-access/integrations/webhooks/#integrationinstallationrepositoriesevent
+type IntegrationInstallationRepositoriesEvent struct {
+	// The action that was performed. Possible values for an "integration_installation_repositories"
+	// event are: "added", "removed".
+	Action              *string       `json:"action,omitempty"`
+	Installation        *Installation `json:"installation,omitempty"`
+	RepositoriesAdded   []*Repository `json:"repositories_added,omitempty"`
+	RepositoriesRemoved []*Repository `json:"repositories_removed,omitempty"`
+	Sender              *User         `json:"sender,omitempty"`
+}
+
+// Installation represents a GitHub integration installation.
+type Installation struct {
+	ID              *int    `json:"id,omitempty"`
+	Account         *User   `json:"account,omitempty"`
+	AccessTokensURL *string `json:"access_tokens_url,omitempty"`
+	RepositoriesURL *string `json:"repositories_url,omitempty"`
+}
+
+// IssueCommentEvent is triggered when an issue comment is created on an issue
+// or pull request.
+// The Webhook event name is "issue_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuecommentevent
+type IssueCommentEvent struct {
+	// Action is the action that was performed on the comment.
+	// Possible values are: "created", "edited", "deleted".
+	Action  *string       `json:"action,omitempty"`
+	Issue   *Issue        `json:"issue,omitempty"`
+	Comment *IssueComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// IssuesEvent is triggered when an issue is assigned, unassigned, labeled,
+// unlabeled, opened, closed, or reopened.
+// The Webhook event name is "issues".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#issuesevent
+type IssuesEvent struct {
+	// Action is the action that was performed. Possible values are: "assigned",
+	// "unassigned", "labeled", "unlabeled", "opened", "closed", "reopened", "edited".
+	Action   *string `json:"action,omitempty"`
+	Issue    *Issue  `json:"issue,omitempty"`
+	Assignee *User   `json:"assignee,omitempty"`
+	Label    *Label  `json:"label,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// MemberEvent is triggered when a user is added as a collaborator to a repository.
+// The Webhook event name is "member".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#memberevent
+type MemberEvent struct {
+	// Action is the action that was performed. Possible value is: "added".
+	Action *string `json:"action,omitempty"`
+	Member *User   `json:"member,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// MembershipEvent is triggered when a user is added or removed from a team.
+// The Webhook event name is "membership".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger organization webhooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#membershipevent
+type MembershipEvent struct {
+	// Action is the action that was performed. Possible values are: "added", "removed".
+	Action *string `json:"action,omitempty"`
+	// Scope is the scope of the membership. Possible value is: "team".
+	Scope  *string `json:"scope,omitempty"`
+	Member *User   `json:"member,omitempty"`
+	Team   *Team   `json:"team,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// PageBuildEvent represents an attempted build of a GitHub Pages site, whether
+// successful or not.
+// The Webhook event name is "page_build".
+//
+// This event is triggered on push to a GitHub Pages enabled branch (gh-pages
+// for project pages, master for user and organization pages).
+//
+// Events of this type are not visible in timelines, they are only used to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pagebuildevent
+type PageBuildEvent struct {
+	Build *PagesBuild `json:"build,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	ID     *int        `json:"id,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// PublicEvent is triggered when a private repository is open sourced.
+// According to GitHub: "Without a doubt: the best GitHub event."
+// The Webhook event name is "public".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#publicevent
+type PublicEvent struct {
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// PullRequestEvent is triggered when a pull request is assigned, unassigned,
+// labeled, unlabeled, opened, closed, reopened, or synchronized.
+// The Webhook event name is "pull_request".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestevent
+type PullRequestEvent struct {
+	// Action is the action that was performed. Possible values are: "assigned",
+	// "unassigned", "labeled", "unlabeled", "opened", "closed", or "reopened",
+	// "synchronize", "edited". If the action is "closed" and the merged key is false,
+	// the pull request was closed with unmerged commits. If the action is "closed"
+	// and the merged key is true, the pull request was merged.
+	Action      *string      `json:"action,omitempty"`
+	Number      *int         `json:"number,omitempty"`
+	PullRequest *PullRequest `json:"pull_request,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// PullRequestReviewCommentEvent is triggered when a comment is created on a
+// portion of the unified diff of a pull request.
+// The Webhook event name is "pull_request_review_comment".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
+type PullRequestReviewCommentEvent struct {
+	// Action is the action that was performed on the comment.
+	// Possible values are: "created", "edited", "deleted".
+	Action      *string             `json:"action,omitempty"`
+	PullRequest *PullRequest        `json:"pull_request,omitempty"`
+	Comment     *PullRequestComment `json:"comment,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Changes *EditChange `json:"changes,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Sender  *User       `json:"sender,omitempty"`
+}
+
+// PushEvent represents a git push to a GitHub repository.
+//
+// GitHub API docs: http://developer.github.com/v3/activity/events/types/#pushevent
+type PushEvent struct {
+	PushID       *int                 `json:"push_id,omitempty"`
+	Head         *string              `json:"head,omitempty"`
+	Ref          *string              `json:"ref,omitempty"`
+	Size         *int                 `json:"size,omitempty"`
+	Commits      []PushEventCommit    `json:"commits,omitempty"`
+	Repo         *PushEventRepository `json:"repository,omitempty"`
+	Before       *string              `json:"before,omitempty"`
+	DistinctSize *int                 `json:"distinct_size,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	After      *string          `json:"after,omitempty"`
+	Created    *bool            `json:"created,omitempty"`
+	Deleted    *bool            `json:"deleted,omitempty"`
+	Forced     *bool            `json:"forced,omitempty"`
+	BaseRef    *string          `json:"base_ref,omitempty"`
+	Compare    *string          `json:"compare,omitempty"`
+	HeadCommit *PushEventCommit `json:"head_commit,omitempty"`
+	Pusher     *User            `json:"pusher,omitempty"`
+	Sender     *User            `json:"sender,omitempty"`
+}
+
+func (p PushEvent) String() string {
+	return Stringify(p)
+}
+
+// PushEventCommit represents a git commit in a GitHub PushEvent.
+type PushEventCommit struct {
+	Message  *string       `json:"message,omitempty"`
+	Author   *CommitAuthor `json:"author,omitempty"`
+	URL      *string       `json:"url,omitempty"`
+	Distinct *bool         `json:"distinct,omitempty"`
+
+	// The following fields are only populated by Events API.
+	SHA *string `json:"sha,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	ID        *string       `json:"id,omitempty"`
+	TreeID    *string       `json:"tree_id,omitempty"`
+	Timestamp *Timestamp    `json:"timestamp,omitempty"`
+	Committer *CommitAuthor `json:"committer,omitempty"`
+	Added     []string      `json:"added,omitempty"`
+	Removed   []string      `json:"removed,omitempty"`
+	Modified  []string      `json:"modified,omitempty"`
+}
+
+func (p PushEventCommit) String() string {
+	return Stringify(p)
+}
+
+// PushEventRepository represents the repo object in a PushEvent payload
+type PushEventRepository struct {
+	ID              *int                `json:"id,omitempty"`
+	Name            *string             `json:"name,omitempty"`
+	FullName        *string             `json:"full_name,omitempty"`
+	Owner           *PushEventRepoOwner `json:"owner,omitempty"`
+	Private         *bool               `json:"private,omitempty"`
+	Description     *string             `json:"description,omitempty"`
+	Fork            *bool               `json:"fork,omitempty"`
+	CreatedAt       *Timestamp          `json:"created_at,omitempty"`
+	PushedAt        *Timestamp          `json:"pushed_at,omitempty"`
+	UpdatedAt       *Timestamp          `json:"updated_at,omitempty"`
+	Homepage        *string             `json:"homepage,omitempty"`
+	Size            *int                `json:"size,omitempty"`
+	StargazersCount *int                `json:"stargazers_count,omitempty"`
+	WatchersCount   *int                `json:"watchers_count,omitempty"`
+	Language        *string             `json:"language,omitempty"`
+	HasIssues       *bool               `json:"has_issues,omitempty"`
+	HasDownloads    *bool               `json:"has_downloads,omitempty"`
+	HasWiki         *bool               `json:"has_wiki,omitempty"`
+	HasPages        *bool               `json:"has_pages,omitempty"`
+	ForksCount      *int                `json:"forks_count,omitempty"`
+	OpenIssuesCount *int                `json:"open_issues_count,omitempty"`
+	DefaultBranch   *string             `json:"default_branch,omitempty"`
+	MasterBranch    *string             `json:"master_branch,omitempty"`
+	Organization    *string             `json:"organization,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	URL     *string `json:"url,omitempty"`
+	HTMLURL *string `json:"html_url,omitempty"`
+}
+
+// PushEventRepoOwner is a basic reporesntation of user/org in a PushEvent payload
+type PushEventRepoOwner struct {
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
+}
+
+// ReleaseEvent is triggered when a release is published.
+// The Webhook event name is "release".
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#releaseevent
+type ReleaseEvent struct {
+	// Action is the action that was performed. Possible value is: "published".
+	Action  *string            `json:"action,omitempty"`
+	Release *RepositoryRelease `json:"release,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}
+
+// RepositoryEvent is triggered when a repository is created.
+// The Webhook event name is "repository".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger organization webhooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#repositoryevent
+type RepositoryEvent struct {
+	// Action is the action that was performed. Possible values are: "created", "deleted",
+	// "publicized", "privatized".
+	Action *string     `json:"action,omitempty"`
+	Repo   *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// StatusEvent is triggered when the status of a Git commit changes.
+// The Webhook event name is "status".
+//
+// Events of this type are not visible in timelines, they are only used to
+// trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#statusevent
+type StatusEvent struct {
+	SHA *string `json:"sha,omitempty"`
+	// State is the new state. Possible values are: "pending", "success", "failure", "error".
+	State       *string   `json:"state,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	TargetURL   *string   `json:"target_url,omitempty"`
+	Branches    []*Branch `json:"branches,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	ID        *int             `json:"id,omitempty"`
+	Name      *string          `json:"name,omitempty"`
+	Context   *string          `json:"context,omitempty"`
+	Commit    *PushEventCommit `json:"commit,omitempty"`
+	CreatedAt *Timestamp       `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp       `json:"updated_at,omitempty"`
+	Repo      *Repository      `json:"repository,omitempty"`
+	Sender    *User            `json:"sender,omitempty"`
+}
+
+// TeamAddEvent is triggered when a repository is added to a team.
+// The Webhook event name is "team_add".
+//
+// Events of this type are not visible in timelines. These events are only used
+// to trigger hooks.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#teamaddevent
+type TeamAddEvent struct {
+	Team *Team       `json:"team,omitempty"`
+	Repo *Repository `json:"repository,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Org    *Organization `json:"organization,omitempty"`
+	Sender *User         `json:"sender,omitempty"`
+}
+
+// WatchEvent is related to starring a repository, not watching. See this API
+// blog post for an explanation: https://developer.github.com/changes/2012-09-05-watcher-api/
+//
+// The event’s actor is the user who starred a repository, and the event’s
+// repository is the repository that was starred.
+//
+// GitHub docs: https://developer.github.com/v3/activity/events/types/#watchevent
+type WatchEvent struct {
+	// Action is the action that was performed. Possible value is: "started".
+	Action *string `json:"action,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo   *Repository `json:"repository,omitempty"`
+	Sender *User       `json:"sender,omitempty"`
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/gists.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/gists.go
@@ -1,0 +1,344 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// GistsService handles communication with the Gist related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/
+type GistsService service
+
+// Gist represents a GitHub's gist.
+type Gist struct {
+	ID          *string                   `json:"id,omitempty"`
+	Description *string                   `json:"description,omitempty"`
+	Public      *bool                     `json:"public,omitempty"`
+	Owner       *User                     `json:"owner,omitempty"`
+	Files       map[GistFilename]GistFile `json:"files,omitempty"`
+	Comments    *int                      `json:"comments,omitempty"`
+	HTMLURL     *string                   `json:"html_url,omitempty"`
+	GitPullURL  *string                   `json:"git_pull_url,omitempty"`
+	GitPushURL  *string                   `json:"git_push_url,omitempty"`
+	CreatedAt   *time.Time                `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time                `json:"updated_at,omitempty"`
+}
+
+func (g Gist) String() string {
+	return Stringify(g)
+}
+
+// GistFilename represents filename on a gist.
+type GistFilename string
+
+// GistFile represents a file on a gist.
+type GistFile struct {
+	Size     *int    `json:"size,omitempty"`
+	Filename *string `json:"filename,omitempty"`
+	Type     *string `json:"type,omitempty"`
+	RawURL   *string `json:"raw_url,omitempty"`
+	Content  *string `json:"content,omitempty"`
+}
+
+func (g GistFile) String() string {
+	return Stringify(g)
+}
+
+// GistCommit represents a commit on a gist.
+type GistCommit struct {
+	URL          *string      `json:"url,omitempty"`
+	Version      *string      `json:"version,omitempty"`
+	User         *User        `json:"user,omitempty"`
+	ChangeStatus *CommitStats `json:"change_status,omitempty"`
+	CommitedAt   *Timestamp   `json:"commited_at,omitempty"`
+}
+
+func (gc GistCommit) String() string {
+	return Stringify(gc)
+}
+
+// GistFork represents a fork of a gist.
+type GistFork struct {
+	URL       *string    `json:"url,omitempty"`
+	User      *User      `json:"user,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+}
+
+func (gf GistFork) String() string {
+	return Stringify(gf)
+}
+
+// GistListOptions specifies the optional parameters to the
+// GistsService.List, GistsService.ListAll, and GistsService.ListStarred methods.
+type GistListOptions struct {
+	// Since filters Gists by time.
+	Since time.Time `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// List gists for a user. Passing the empty string will list
+// all public gists if called anonymously. However, if the call
+// is authenticated, it will returns all gists for the authenticated
+// user.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#list-gists
+func (s *GistsService) List(user string, opt *GistListOptions) ([]*Gist, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/gists", user)
+	} else {
+		u = "gists"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gists := new([]*Gist)
+	resp, err := s.client.Do(req, gists)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *gists, resp, err
+}
+
+// ListAll lists all public gists.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#list-gists
+func (s *GistsService) ListAll(opt *GistListOptions) ([]*Gist, *Response, error) {
+	u, err := addOptions("gists/public", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gists := new([]*Gist)
+	resp, err := s.client.Do(req, gists)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *gists, resp, err
+}
+
+// ListStarred lists starred gists of authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#list-gists
+func (s *GistsService) ListStarred(opt *GistListOptions) ([]*Gist, *Response, error) {
+	u, err := addOptions("gists/starred", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gists := new([]*Gist)
+	resp, err := s.client.Do(req, gists)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *gists, resp, err
+}
+
+// Get a single gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#get-a-single-gist
+func (s *GistsService) Get(id string) (*Gist, *Response, error) {
+	u := fmt.Sprintf("gists/%v", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	gist := new(Gist)
+	resp, err := s.client.Do(req, gist)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gist, resp, err
+}
+
+// GetRevision gets a specific revision of a gist.
+//
+// GitHub API docs: https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist
+func (s *GistsService) GetRevision(id, sha string) (*Gist, *Response, error) {
+	u := fmt.Sprintf("gists/%v/%v", id, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	gist := new(Gist)
+	resp, err := s.client.Do(req, gist)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gist, resp, err
+}
+
+// Create a gist for authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#create-a-gist
+func (s *GistsService) Create(gist *Gist) (*Gist, *Response, error) {
+	u := "gists"
+	req, err := s.client.NewRequest("POST", u, gist)
+	if err != nil {
+		return nil, nil, err
+	}
+	g := new(Gist)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// Edit a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#edit-a-gist
+func (s *GistsService) Edit(id string, gist *Gist) (*Gist, *Response, error) {
+	u := fmt.Sprintf("gists/%v", id)
+	req, err := s.client.NewRequest("PATCH", u, gist)
+	if err != nil {
+		return nil, nil, err
+	}
+	g := new(Gist)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// ListCommits lists commits of a gist.
+//
+// Github API docs: https://developer.github.com/v3/gists/#list-gist-commits
+func (s *GistsService) ListCommits(id string) ([]*GistCommit, *Response, error) {
+	u := fmt.Sprintf("gists/%v/commits", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gistCommits := new([]*GistCommit)
+	resp, err := s.client.Do(req, gistCommits)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *gistCommits, resp, err
+}
+
+// Delete a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#delete-a-gist
+func (s *GistsService) Delete(id string) (*Response, error) {
+	u := fmt.Sprintf("gists/%v", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// Star a gist on behalf of authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#star-a-gist
+func (s *GistsService) Star(id string) (*Response, error) {
+	u := fmt.Sprintf("gists/%v/star", id)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// Unstar a gist on a behalf of authenticated user.
+//
+// Github API docs: http://developer.github.com/v3/gists/#unstar-a-gist
+func (s *GistsService) Unstar(id string) (*Response, error) {
+	u := fmt.Sprintf("gists/%v/star", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// IsStarred checks if a gist is starred by authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#check-if-a-gist-is-starred
+func (s *GistsService) IsStarred(id string) (bool, *Response, error) {
+	u := fmt.Sprintf("gists/%v/star", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	starred, err := parseBoolResponse(err)
+	return starred, resp, err
+}
+
+// Fork a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/#fork-a-gist
+func (s *GistsService) Fork(id string) (*Gist, *Response, error) {
+	u := fmt.Sprintf("gists/%v/forks", id)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Gist)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// ListForks lists forks of a gist.
+//
+// Github API docs: https://developer.github.com/v3/gists/#list-gist-forks
+func (s *GistsService) ListForks(id string) ([]*GistFork, *Response, error) {
+	u := fmt.Sprintf("gists/%v/forks", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gistForks := new([]*GistFork)
+	resp, err := s.client.Do(req, gistForks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *gistForks, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/gists_comments.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/gists_comments.go
@@ -1,0 +1,118 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// GistComment represents a Gist comment.
+type GistComment struct {
+	ID        *int       `json:"id,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	Body      *string    `json:"body,omitempty"`
+	User      *User      `json:"user,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+}
+
+func (g GistComment) String() string {
+	return Stringify(g)
+}
+
+// ListComments lists all comments for a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist
+func (s *GistsService) ListComments(gistID string, opt *ListOptions) ([]*GistComment, *Response, error) {
+	u := fmt.Sprintf("gists/%v/comments", gistID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	comments := new([]*GistComment)
+	resp, err := s.client.Do(req, comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *comments, resp, err
+}
+
+// GetComment retrieves a single comment from a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/comments/#get-a-single-comment
+func (s *GistsService) GetComment(gistID string, commentID int) (*GistComment, *Response, error) {
+	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(GistComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// CreateComment creates a comment for a gist.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/comments/#create-a-comment
+func (s *GistsService) CreateComment(gistID string, comment *GistComment) (*GistComment, *Response, error) {
+	u := fmt.Sprintf("gists/%v/comments", gistID)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(GistComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// EditComment edits an existing gist comment.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/comments/#edit-a-comment
+func (s *GistsService) EditComment(gistID string, commentID int, comment *GistComment) (*GistComment, *Response, error) {
+	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(GistComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// DeleteComment deletes a gist comment.
+//
+// GitHub API docs: http://developer.github.com/v3/gists/comments/#delete-a-comment
+func (s *GistsService) DeleteComment(gistID string, commentID int) (*Response, error) {
+	u := fmt.Sprintf("gists/%v/comments/%v", gistID, commentID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// GitService handles communication with the git data related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/git/
+type GitService service

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_blobs.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_blobs.go
@@ -1,0 +1,47 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Blob represents a blob object.
+type Blob struct {
+	Content  *string `json:"content,omitempty"`
+	Encoding *string `json:"encoding,omitempty"`
+	SHA      *string `json:"sha,omitempty"`
+	Size     *int    `json:"size,omitempty"`
+	URL      *string `json:"url,omitempty"`
+}
+
+// GetBlob fetchs a blob from a repo given a SHA.
+//
+// GitHub API docs: http://developer.github.com/v3/git/blobs/#get-a-blob
+func (s *GitService) GetBlob(owner string, repo string, sha string) (*Blob, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/blobs/%v", owner, repo, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	blob := new(Blob)
+	resp, err := s.client.Do(req, blob)
+	return blob, resp, err
+}
+
+// CreateBlob creates a blob object.
+//
+// GitHub API docs: https://developer.github.com/v3/git/blobs/#create-a-blob
+func (s *GitService) CreateBlob(owner string, repo string, blob *Blob) (*Blob, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/blobs", owner, repo)
+	req, err := s.client.NewRequest("POST", u, blob)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Blob)
+	resp, err := s.client.Do(req, t)
+	return t, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_commits.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_commits.go
@@ -1,0 +1,127 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// SignatureVerification represents GPG signature verification.
+type SignatureVerification struct {
+	Verified  *bool   `json:"verified,omitempty"`
+	Reason    *string `json:"reason,omitempty"`
+	Signature *string `json:"signature,omitempty"`
+	Payload   *string `json:"payload,omitempty"`
+}
+
+// Commit represents a GitHub commit.
+type Commit struct {
+	SHA          *string                `json:"sha,omitempty"`
+	Author       *CommitAuthor          `json:"author,omitempty"`
+	Committer    *CommitAuthor          `json:"committer,omitempty"`
+	Message      *string                `json:"message,omitempty"`
+	Tree         *Tree                  `json:"tree,omitempty"`
+	Parents      []Commit               `json:"parents,omitempty"`
+	Stats        *CommitStats           `json:"stats,omitempty"`
+	URL          *string                `json:"url,omitempty"`
+	Verification *SignatureVerification `json:"verification,omitempty"`
+
+	// CommentCount is the number of GitHub comments on the commit.  This
+	// is only populated for requests that fetch GitHub data like
+	// Pulls.ListCommits, Repositories.ListCommits, etc.
+	CommentCount *int `json:"comment_count,omitempty"`
+}
+
+func (c Commit) String() string {
+	return Stringify(c)
+}
+
+// CommitAuthor represents the author or committer of a commit.  The commit
+// author may not correspond to a GitHub User.
+type CommitAuthor struct {
+	Date  *time.Time `json:"date,omitempty"`
+	Name  *string    `json:"name,omitempty"`
+	Email *string    `json:"email,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Login *string `json:"username,omitempty"` // Renamed for go-github consistency.
+}
+
+func (c CommitAuthor) String() string {
+	return Stringify(c)
+}
+
+// GetCommit fetchs the Commit object for a given SHA.
+//
+// GitHub API docs: http://developer.github.com/v3/git/commits/#get-a-commit
+func (s *GitService) GetCommit(owner string, repo string, sha string) (*Commit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/commits/%v", owner, repo, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	c := new(Commit)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// createCommit represents the body of a CreateCommit request.
+type createCommit struct {
+	Author    *CommitAuthor `json:"author,omitempty"`
+	Committer *CommitAuthor `json:"committer,omitempty"`
+	Message   *string       `json:"message,omitempty"`
+	Tree      *string       `json:"tree,omitempty"`
+	Parents   []string      `json:"parents,omitempty"`
+}
+
+// CreateCommit creates a new commit in a repository.
+//
+// The commit.Committer is optional and will be filled with the commit.Author
+// data if omitted. If the commit.Author is omitted, it will be filled in with
+// the authenticated user’s information and the current date.
+//
+// GitHub API docs: http://developer.github.com/v3/git/commits/#create-a-commit
+func (s *GitService) CreateCommit(owner string, repo string, commit *Commit) (*Commit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/commits", owner, repo)
+
+	body := &createCommit{}
+	if commit != nil {
+		parents := make([]string, len(commit.Parents))
+		for i, parent := range commit.Parents {
+			parents[i] = *parent.SHA
+		}
+
+		body = &createCommit{
+			Author:    commit.Author,
+			Committer: commit.Committer,
+			Message:   commit.Message,
+			Tree:      commit.Tree.SHA,
+			Parents:   parents,
+		}
+	}
+
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(Commit)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_refs.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_refs.go
@@ -1,0 +1,162 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Reference represents a GitHub reference.
+type Reference struct {
+	Ref    *string    `json:"ref"`
+	URL    *string    `json:"url"`
+	Object *GitObject `json:"object"`
+}
+
+func (r Reference) String() string {
+	return Stringify(r)
+}
+
+// GitObject represents a Git object.
+type GitObject struct {
+	Type *string `json:"type"`
+	SHA  *string `json:"sha"`
+	URL  *string `json:"url"`
+}
+
+func (o GitObject) String() string {
+	return Stringify(o)
+}
+
+// createRefRequest represents the payload for creating a reference.
+type createRefRequest struct {
+	Ref *string `json:"ref"`
+	SHA *string `json:"sha"`
+}
+
+// updateRefRequest represents the payload for updating a reference.
+type updateRefRequest struct {
+	SHA   *string `json:"sha"`
+	Force *bool   `json:"force"`
+}
+
+// GetRef fetches the Reference object for a given Git ref.
+//
+// GitHub API docs: http://developer.github.com/v3/git/refs/#get-a-reference
+func (s *GitService) GetRef(owner string, repo string, ref string) (*Reference, *Response, error) {
+	ref = strings.TrimPrefix(ref, "refs/")
+	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, ref)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Reference)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// ReferenceListOptions specifies optional parameters to the
+// GitService.ListRefs method.
+type ReferenceListOptions struct {
+	Type string `url:"-"`
+
+	ListOptions
+}
+
+// ListRefs lists all refs in a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/git/refs/#get-all-references
+func (s *GitService) ListRefs(owner, repo string, opt *ReferenceListOptions) ([]*Reference, *Response, error) {
+	var u string
+	if opt != nil && opt.Type != "" {
+		u = fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, opt.Type)
+	} else {
+		u = fmt.Sprintf("repos/%v/%v/git/refs", owner, repo)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*Reference
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// CreateRef creates a new ref in a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/git/refs/#create-a-reference
+func (s *GitService) CreateRef(owner string, repo string, ref *Reference) (*Reference, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/refs", owner, repo)
+	req, err := s.client.NewRequest("POST", u, &createRefRequest{
+		// back-compat with previous behavior that didn't require 'refs/' prefix
+		Ref: String("refs/" + strings.TrimPrefix(*ref.Ref, "refs/")),
+		SHA: ref.Object.SHA,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Reference)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// UpdateRef updates an existing ref in a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/git/refs/#update-a-reference
+func (s *GitService) UpdateRef(owner string, repo string, ref *Reference, force bool) (*Reference, *Response, error) {
+	refPath := strings.TrimPrefix(*ref.Ref, "refs/")
+	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, refPath)
+	req, err := s.client.NewRequest("PATCH", u, &updateRefRequest{
+		SHA:   ref.Object.SHA,
+		Force: &force,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Reference)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// DeleteRef deletes a ref from a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/git/refs/#delete-a-reference
+func (s *GitService) DeleteRef(owner string, repo string, ref string) (*Response, error) {
+	ref = strings.TrimPrefix(ref, "refs/")
+	u := fmt.Sprintf("repos/%v/%v/git/refs/%v", owner, repo, ref)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_tags.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_tags.go
@@ -1,0 +1,77 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+)
+
+// Tag represents a tag object.
+type Tag struct {
+	Tag          *string                `json:"tag,omitempty"`
+	SHA          *string                `json:"sha,omitempty"`
+	URL          *string                `json:"url,omitempty"`
+	Message      *string                `json:"message,omitempty"`
+	Tagger       *CommitAuthor          `json:"tagger,omitempty"`
+	Object       *GitObject             `json:"object,omitempty"`
+	Verification *SignatureVerification `json:"verification,omitempty"`
+}
+
+// createTagRequest represents the body of a CreateTag request.  This is mostly
+// identical to Tag with the exception that the object SHA and Type are
+// top-level fields, rather than being nested inside a JSON object.
+type createTagRequest struct {
+	Tag     *string       `json:"tag,omitempty"`
+	Message *string       `json:"message,omitempty"`
+	Object  *string       `json:"object,omitempty"`
+	Type    *string       `json:"type,omitempty"`
+	Tagger  *CommitAuthor `json:"tagger,omitempty"`
+}
+
+// GetTag fetchs a tag from a repo given a SHA.
+//
+// GitHub API docs: http://developer.github.com/v3/git/tags/#get-a-tag
+func (s *GitService) GetTag(owner string, repo string, sha string) (*Tag, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/tags/%v", owner, repo, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	tag := new(Tag)
+	resp, err := s.client.Do(req, tag)
+	return tag, resp, err
+}
+
+// CreateTag creates a tag object.
+//
+// GitHub API docs: http://developer.github.com/v3/git/tags/#create-a-tag-object
+func (s *GitService) CreateTag(owner string, repo string, tag *Tag) (*Tag, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/tags", owner, repo)
+
+	// convert Tag into a createTagRequest
+	tagRequest := &createTagRequest{
+		Tag:     tag.Tag,
+		Message: tag.Message,
+		Tagger:  tag.Tagger,
+	}
+	if tag.Object != nil {
+		tagRequest.Object = tag.Object.SHA
+		tagRequest.Type = tag.Object.Type
+	}
+
+	req, err := s.client.NewRequest("POST", u, tagRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Tag)
+	resp, err := s.client.Do(req, t)
+	return t, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_trees.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/git_trees.go
@@ -1,0 +1,89 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Tree represents a GitHub tree.
+type Tree struct {
+	SHA     *string     `json:"sha,omitempty"`
+	Entries []TreeEntry `json:"tree,omitempty"`
+}
+
+func (t Tree) String() string {
+	return Stringify(t)
+}
+
+// TreeEntry represents the contents of a tree structure.  TreeEntry can
+// represent either a blob, a commit (in the case of a submodule), or another
+// tree.
+type TreeEntry struct {
+	SHA     *string `json:"sha,omitempty"`
+	Path    *string `json:"path,omitempty"`
+	Mode    *string `json:"mode,omitempty"`
+	Type    *string `json:"type,omitempty"`
+	Size    *int    `json:"size,omitempty"`
+	Content *string `json:"content,omitempty"`
+}
+
+func (t TreeEntry) String() string {
+	return Stringify(t)
+}
+
+// GetTree fetches the Tree object for a given sha hash from a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/git/trees/#get-a-tree
+func (s *GitService) GetTree(owner string, repo string, sha string, recursive bool) (*Tree, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/trees/%v", owner, repo, sha)
+	if recursive {
+		u += "?recursive=1"
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Tree)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// createTree represents the body of a CreateTree request.
+type createTree struct {
+	BaseTree string      `json:"base_tree,omitempty"`
+	Entries  []TreeEntry `json:"tree"`
+}
+
+// CreateTree creates a new tree in a repository.  If both a tree and a nested
+// path modifying that tree are specified, it will overwrite the contents of
+// that tree with the new path contents and write a new tree out.
+//
+// GitHub API docs: http://developer.github.com/v3/git/trees/#create-a-tree
+func (s *GitService) CreateTree(owner string, repo string, baseTree string, entries []TreeEntry) (*Tree, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/git/trees", owner, repo)
+
+	body := &createTree{
+		BaseTree: baseTree,
+		Entries:  entries,
+	}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Tree)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/github.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/github.go
@@ -1,0 +1,847 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-querystring/query"
+)
+
+const (
+	// StatusUnprocessableEntity is the status code returned when sending a request with invalid fields.
+	StatusUnprocessableEntity = 422
+)
+
+const (
+	libraryVersion = "2"
+	defaultBaseURL = "https://api.github.com/"
+	uploadBaseURL  = "https://uploads.github.com/"
+	userAgent      = "go-github/" + libraryVersion
+
+	headerRateLimit     = "X-RateLimit-Limit"
+	headerRateRemaining = "X-RateLimit-Remaining"
+	headerRateReset     = "X-RateLimit-Reset"
+	headerOTP           = "X-GitHub-OTP"
+
+	mediaTypeV3                = "application/vnd.github.v3+json"
+	defaultMediaType           = "application/octet-stream"
+	mediaTypeV3SHA             = "application/vnd.github.v3.sha"
+	mediaTypeOrgPermissionRepo = "application/vnd.github.v3.repository+json"
+
+	// Media Type values to access preview APIs
+
+	// https://developer.github.com/changes/2015-03-09-licenses-api/
+	mediaTypeLicensesPreview = "application/vnd.github.drax-preview+json"
+
+	// https://developer.github.com/changes/2014-12-09-new-attributes-for-stars-api/
+	mediaTypeStarringPreview = "application/vnd.github.v3.star+json"
+
+	// https://developer.github.com/changes/2015-11-11-protected-branches-api/
+	mediaTypeProtectedBranchesPreview = "application/vnd.github.loki-preview+json"
+
+	// https://help.github.com/enterprise/2.4/admin/guides/migrations/exporting-the-github-com-organization-s-repositories/
+	mediaTypeMigrationsPreview = "application/vnd.github.wyandotte-preview+json"
+
+	// https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
+	mediaTypeDeploymentStatusPreview = "application/vnd.github.ant-man-preview+json"
+
+	// https://developer.github.com/changes/2016-02-19-source-import-preview-api/
+	mediaTypeImportPreview = "application/vnd.github.barred-rock-preview"
+
+	// https://developer.github.com/changes/2016-05-12-reactions-api-preview/
+	mediaTypeReactionsPreview = "application/vnd.github.squirrel-girl-preview"
+
+	// https://developer.github.com/changes/2016-04-01-squash-api-preview/
+	mediaTypeSquashPreview = "application/vnd.github.polaris-preview+json"
+
+	// https://developer.github.com/changes/2016-04-04-git-signing-api-preview/
+	mediaTypeGitSigningPreview = "application/vnd.github.cryptographer-preview+json"
+
+	// https://developer.github.com/changes/2016-05-23-timeline-preview-api/
+	mediaTypeTimelinePreview = "application/vnd.github.mockingbird-preview+json"
+
+	// https://developer.github.com/changes/2016-06-14-repository-invitations/
+	mediaTypeRepositoryInvitationsPreview = "application/vnd.github.swamp-thing-preview+json"
+
+	// https://developer.github.com/changes/2016-04-21-oauth-authorizations-grants-api-preview/
+	mediaTypeOAuthGrantAuthorizationsPreview = "application/vnd.github.damage-preview+json"
+
+	// https://developer.github.com/changes/2016-07-06-github-pages-preiew-api/
+	mediaTypePagesPreview = "application/vnd.github.mister-fantastic-preview+json"
+
+	// https://developer.github.com/v3/repos/traffic/
+	mediaTypeTrafficPreview = "application/vnd.github.spiderman-preview+json"
+
+	// https://developer.github.com/changes/2016-09-14-projects-api/
+	mediaTypeProjectsPreview = "application/vnd.github.inertia-preview+json"
+)
+
+// A Client manages communication with the GitHub API.
+type Client struct {
+	clientMu sync.Mutex   // clientMu protects the client during calls that modify the CheckRedirect func.
+	client   *http.Client // HTTP client used to communicate with the API.
+
+	// Base URL for API requests.  Defaults to the public GitHub API, but can be
+	// set to a domain endpoint to use with GitHub Enterprise.  BaseURL should
+	// always be specified with a trailing slash.
+	BaseURL *url.URL
+
+	// Base URL for uploading files.
+	UploadURL *url.URL
+
+	// User agent used when communicating with the GitHub API.
+	UserAgent string
+
+	rateMu     sync.Mutex
+	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
+	mostRecent rateLimitCategory
+
+	common service // Reuse a single struct instead of allocating one for each service on the heap.
+
+	// Services used for talking to different parts of the GitHub API.
+	Activity       *ActivityService
+	Authorizations *AuthorizationsService
+	Gists          *GistsService
+	Git            *GitService
+	Gitignores     *GitignoresService
+	Issues         *IssuesService
+	Organizations  *OrganizationsService
+	PullRequests   *PullRequestsService
+	Repositories   *RepositoriesService
+	Search         *SearchService
+	Users          *UsersService
+	Licenses       *LicensesService
+	Migrations     *MigrationService
+	Reactions      *ReactionsService
+}
+
+type service struct {
+	client *Client
+}
+
+// ListOptions specifies the optional parameters to various List methods that
+// support pagination.
+type ListOptions struct {
+	// For paginated result sets, page of results to retrieve.
+	Page int `url:"page,omitempty"`
+
+	// For paginated result sets, the number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
+}
+
+// UploadOptions specifies the parameters to methods that support uploads.
+type UploadOptions struct {
+	Name string `url:"name,omitempty"`
+}
+
+// addOptions adds the parameters in opt as URL query parameters to s.  opt
+// must be a struct whose fields may contain "url" tags.
+func addOptions(s string, opt interface{}) (string, error) {
+	v := reflect.ValueOf(opt)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return s, nil
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return s, err
+	}
+
+	qs, err := query.Values(opt)
+	if err != nil {
+		return s, err
+	}
+
+	u.RawQuery = qs.Encode()
+	return u.String(), nil
+}
+
+// NewClient returns a new GitHub API client.  If a nil httpClient is
+// provided, http.DefaultClient will be used.  To use API methods which require
+// authentication, provide an http.Client that will perform the authentication
+// for you (such as that provided by the golang.org/x/oauth2 library).
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	baseURL, _ := url.Parse(defaultBaseURL)
+	uploadURL, _ := url.Parse(uploadBaseURL)
+
+	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, UploadURL: uploadURL}
+	c.common.client = c
+	c.Activity = (*ActivityService)(&c.common)
+	c.Authorizations = (*AuthorizationsService)(&c.common)
+	c.Gists = (*GistsService)(&c.common)
+	c.Git = (*GitService)(&c.common)
+	c.Gitignores = (*GitignoresService)(&c.common)
+	c.Issues = (*IssuesService)(&c.common)
+	c.Licenses = (*LicensesService)(&c.common)
+	c.Migrations = (*MigrationService)(&c.common)
+	c.Organizations = (*OrganizationsService)(&c.common)
+	c.PullRequests = (*PullRequestsService)(&c.common)
+	c.Reactions = (*ReactionsService)(&c.common)
+	c.Repositories = (*RepositoriesService)(&c.common)
+	c.Search = (*SearchService)(&c.common)
+	c.Users = (*UsersService)(&c.common)
+	return c
+}
+
+// NewRequest creates an API request. A relative URL can be provided in urlStr,
+// in which case it is resolved relative to the BaseURL of the Client.
+// Relative URLs should always be specified without a preceding slash.  If
+// specified, the value pointed to by body is JSON encoded and included as the
+// request body.
+func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		err := json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", mediaTypeV3)
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	return req, nil
+}
+
+// NewUploadRequest creates an upload request. A relative URL can be provided in
+// urlStr, in which case it is resolved relative to the UploadURL of the Client.
+// Relative URLs should always be specified without a preceding slash.
+func (c *Client) NewUploadRequest(urlStr string, reader io.Reader, size int64, mediaType string) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.UploadURL.ResolveReference(rel)
+	req, err := http.NewRequest("POST", u.String(), reader)
+	if err != nil {
+		return nil, err
+	}
+	req.ContentLength = size
+
+	if mediaType == "" {
+		mediaType = defaultMediaType
+	}
+	req.Header.Set("Content-Type", mediaType)
+	req.Header.Set("Accept", mediaTypeV3)
+	req.Header.Set("User-Agent", c.UserAgent)
+	return req, nil
+}
+
+// Response is a GitHub API response.  This wraps the standard http.Response
+// returned from GitHub and provides convenient access to things like
+// pagination links.
+type Response struct {
+	*http.Response
+
+	// These fields provide the page values for paginating through a set of
+	// results.  Any or all of these may be set to the zero value for
+	// responses that are not part of a paginated set, or for which there
+	// are no additional pages.
+
+	NextPage  int
+	PrevPage  int
+	FirstPage int
+	LastPage  int
+
+	Rate
+}
+
+// newResponse creates a new Response for the provided http.Response.
+func newResponse(r *http.Response) *Response {
+	response := &Response{Response: r}
+	response.populatePageValues()
+	response.Rate = parseRate(r)
+	return response
+}
+
+// populatePageValues parses the HTTP Link response headers and populates the
+// various pagination link values in the Response.
+func (r *Response) populatePageValues() {
+	if links, ok := r.Response.Header["Link"]; ok && len(links) > 0 {
+		for _, link := range strings.Split(links[0], ",") {
+			segments := strings.Split(strings.TrimSpace(link), ";")
+
+			// link must at least have href and rel
+			if len(segments) < 2 {
+				continue
+			}
+
+			// ensure href is properly formatted
+			if !strings.HasPrefix(segments[0], "<") || !strings.HasSuffix(segments[0], ">") {
+				continue
+			}
+
+			// try to pull out page parameter
+			url, err := url.Parse(segments[0][1 : len(segments[0])-1])
+			if err != nil {
+				continue
+			}
+			page := url.Query().Get("page")
+			if page == "" {
+				continue
+			}
+
+			for _, segment := range segments[1:] {
+				switch strings.TrimSpace(segment) {
+				case `rel="next"`:
+					r.NextPage, _ = strconv.Atoi(page)
+				case `rel="prev"`:
+					r.PrevPage, _ = strconv.Atoi(page)
+				case `rel="first"`:
+					r.FirstPage, _ = strconv.Atoi(page)
+				case `rel="last"`:
+					r.LastPage, _ = strconv.Atoi(page)
+				}
+
+			}
+		}
+	}
+}
+
+// parseRate parses the rate related headers.
+func parseRate(r *http.Response) Rate {
+	var rate Rate
+	if limit := r.Header.Get(headerRateLimit); limit != "" {
+		rate.Limit, _ = strconv.Atoi(limit)
+	}
+	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
+		rate.Remaining, _ = strconv.Atoi(remaining)
+	}
+	if reset := r.Header.Get(headerRateReset); reset != "" {
+		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
+			rate.Reset = Timestamp{time.Unix(v, 0)}
+		}
+	}
+	return rate
+}
+
+// Rate specifies the current rate limit for the client as determined by the
+// most recent API call.  If the client is used in a multi-user application,
+// this rate may not always be up-to-date.
+//
+// Deprecated: Use the Response.Rate returned from most recent API call instead.
+// Call RateLimits() to check the current rate.
+func (c *Client) Rate() Rate {
+	c.rateMu.Lock()
+	rate := c.rateLimits[c.mostRecent]
+	c.rateMu.Unlock()
+	return rate
+}
+
+// Do sends an API request and returns the API response.  The API response is
+// JSON decoded and stored in the value pointed to by v, or returned as an
+// error if an API error has occurred.  If v implements the io.Writer
+// interface, the raw response body will be written to v, without attempting to
+// first decode it.  If rate limit is exceeded and reset time is in the future,
+// Do returns *RateLimitError immediately without making a network API call.
+func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
+	rateLimitCategory := category(req.URL.Path)
+
+	// If we've hit rate limit, don't make further requests before Reset time.
+	if err := c.checkRateLimitBeforeDo(req, rateLimitCategory); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
+		resp.Body.Close()
+	}()
+
+	response := newResponse(resp)
+
+	c.rateMu.Lock()
+	c.rateLimits[rateLimitCategory] = response.Rate
+	c.mostRecent = rateLimitCategory
+	c.rateMu.Unlock()
+
+	err = CheckResponse(resp)
+	if err != nil {
+		// even though there was an error, we still return the response
+		// in case the caller wants to inspect it further
+		return response, err
+	}
+
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			io.Copy(w, resp.Body)
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+			if err == io.EOF {
+				err = nil // ignore EOF errors caused by empty response body
+			}
+		}
+	}
+
+	return response, err
+}
+
+// checkRateLimitBeforeDo does not make any network calls, but uses existing knowledge from
+// current client state in order to quickly check if *RateLimitError can be immediately returned
+// from Client.Do, and if so, returns it so that Client.Do can skip making a network API call unnecessarily.
+// Otherwise it returns nil, and Client.Do should proceed normally.
+func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory rateLimitCategory) error {
+	c.rateMu.Lock()
+	rate := c.rateLimits[rateLimitCategory]
+	c.rateMu.Unlock()
+	if !rate.Reset.Time.IsZero() && rate.Remaining == 0 && time.Now().Before(rate.Reset.Time) {
+		// Create a fake response.
+		resp := &http.Response{
+			Status:     http.StatusText(http.StatusForbidden),
+			StatusCode: http.StatusForbidden,
+			Request:    req,
+			Header:     make(http.Header),
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}
+		return &RateLimitError{
+			Rate:     rate,
+			Response: resp,
+			Message:  fmt.Sprintf("API rate limit of %v still exceeded until %v, not making remote request.", rate.Limit, rate.Reset.Time),
+		}
+	}
+
+	return nil
+}
+
+/*
+An ErrorResponse reports one or more errors caused by an API request.
+
+GitHub API docs: http://developer.github.com/v3/#client-errors
+*/
+type ErrorResponse struct {
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // error message
+	Errors   []Error        `json:"errors"`  // more detail on individual errors
+	// Block is only populated on certain types of errors such as code 451.
+	// See https://developer.github.com/changes/2016-03-17-the-451-status-code-is-now-supported/
+	// for more information.
+	Block *struct {
+		Reason    string     `json:"reason,omitempty"`
+		CreatedAt *Timestamp `json:"created_at,omitempty"`
+	} `json:"block,omitempty"`
+	// Most errors will also include a documentation_url field pointing
+	// to some content that might help you resolve the error, see
+	// https://developer.github.com/v3/#client-errors
+	DocumentationURL string `json:"documentation_url,omitempty"`
+}
+
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %d %v %+v",
+		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
+		r.Response.StatusCode, r.Message, r.Errors)
+}
+
+// TwoFactorAuthError occurs when using HTTP Basic Authentication for a user
+// that has two-factor authentication enabled.  The request can be reattempted
+// by providing a one-time password in the request.
+type TwoFactorAuthError ErrorResponse
+
+func (r *TwoFactorAuthError) Error() string { return (*ErrorResponse)(r).Error() }
+
+// RateLimitError occurs when GitHub returns 403 Forbidden response with a rate limit
+// remaining value of 0, and error message starts with "API rate limit exceeded for ".
+type RateLimitError struct {
+	Rate     Rate           // Rate specifies last known rate limit for the client
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // error message
+}
+
+func (r *RateLimitError) Error() string {
+	return fmt.Sprintf("%v %v: %d %v; rate reset in %v",
+		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
+		r.Response.StatusCode, r.Message, r.Rate.Reset.Time.Sub(time.Now()))
+}
+
+// AbuseRateLimitError occurs when GitHub returns 403 Forbidden response with the
+// "documentation_url" field value equal to "https://developer.github.com/v3#abuse-rate-limits".
+type AbuseRateLimitError struct {
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // error message
+
+	// RetryAfter is provided with some abuse rate limit errors. If present,
+	// it is the amount of time that the client should wait before retrying.
+	// Otherwise, the client should try again later (after an unspecified amount of time).
+	RetryAfter *time.Duration
+}
+
+func (r *AbuseRateLimitError) Error() string {
+	return fmt.Sprintf("%v %v: %d %v",
+		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
+		r.Response.StatusCode, r.Message)
+}
+
+// sanitizeURL redacts the client_secret parameter from the URL which may be
+// exposed to the user, specifically in the ErrorResponse error message.
+func sanitizeURL(uri *url.URL) *url.URL {
+	if uri == nil {
+		return nil
+	}
+	params := uri.Query()
+	if len(params.Get("client_secret")) > 0 {
+		params.Set("client_secret", "REDACTED")
+		uri.RawQuery = params.Encode()
+	}
+	return uri
+}
+
+/*
+An Error reports more details on an individual error in an ErrorResponse.
+These are the possible validation error codes:
+
+    missing:
+        resource does not exist
+    missing_field:
+        a required field on a resource has not been set
+    invalid:
+        the formatting of a field is invalid
+    already_exists:
+        another resource has the same valid as this field
+    custom:
+        some resources return this (e.g. github.User.CreateKey()), additional
+        information is set in the Message field of the Error
+
+GitHub API docs: http://developer.github.com/v3/#client-errors
+*/
+type Error struct {
+	Resource string `json:"resource"` // resource on which the error occurred
+	Field    string `json:"field"`    // field on which the error occurred
+	Code     string `json:"code"`     // validation error code
+	Message  string `json:"message"`  // Message describing the error. Errors with Code == "custom" will always have this set.
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%v error caused by %v field on %v resource",
+		e.Code, e.Field, e.Resource)
+}
+
+// CheckResponse checks the API response for errors, and returns them if
+// present.  A response is considered an error if it has a status code outside
+// the 200 range.  API error responses are expected to have either no response
+// body, or a JSON response body that maps to ErrorResponse.  Any other
+// response body will be silently ignored.
+//
+// The error type will be *RateLimitError for rate limit exceeded errors,
+// and *TwoFactorAuthError for two-factor authentication errors.
+func CheckResponse(r *http.Response) error {
+	if c := r.StatusCode; 200 <= c && c <= 299 {
+		return nil
+	}
+	errorResponse := &ErrorResponse{Response: r}
+	data, err := ioutil.ReadAll(r.Body)
+	if err == nil && data != nil {
+		json.Unmarshal(data, errorResponse)
+	}
+	switch {
+	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
+		return (*TwoFactorAuthError)(errorResponse)
+	case r.StatusCode == http.StatusForbidden && r.Header.Get(headerRateRemaining) == "0" && strings.HasPrefix(errorResponse.Message, "API rate limit exceeded for "):
+		return &RateLimitError{
+			Rate:     parseRate(r),
+			Response: errorResponse.Response,
+			Message:  errorResponse.Message,
+		}
+	case r.StatusCode == http.StatusForbidden && errorResponse.DocumentationURL == "https://developer.github.com/v3#abuse-rate-limits":
+		abuseRateLimitError := &AbuseRateLimitError{
+			Response: errorResponse.Response,
+			Message:  errorResponse.Message,
+		}
+		if v := r.Header["Retry-After"]; len(v) > 0 {
+			// According to GitHub support, the "Retry-After" header value will be
+			// an integer which represents the number of seconds that one should
+			// wait before resuming making requests.
+			retryAfterSeconds, _ := strconv.ParseInt(v[0], 10, 64) // Error handling is noop.
+			retryAfter := time.Duration(retryAfterSeconds) * time.Second
+			abuseRateLimitError.RetryAfter = &retryAfter
+		}
+		return abuseRateLimitError
+	default:
+		return errorResponse
+	}
+}
+
+// parseBoolResponse determines the boolean result from a GitHub API response.
+// Several GitHub API methods return boolean responses indicated by the HTTP
+// status code in the response (true indicated by a 204, false indicated by a
+// 404).  This helper function will determine that result and hide the 404
+// error if present.  Any other error will be returned through as-is.
+func parseBoolResponse(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+
+	if err, ok := err.(*ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
+		// Simply false.  In this one case, we do not pass the error through.
+		return false, nil
+	}
+
+	// some other real error occurred
+	return false, err
+}
+
+// Rate represents the rate limit for the current client.
+type Rate struct {
+	// The number of requests per hour the client is currently limited to.
+	Limit int `json:"limit"`
+
+	// The number of remaining requests the client can make this hour.
+	Remaining int `json:"remaining"`
+
+	// The time at which the current rate limit will reset.
+	Reset Timestamp `json:"reset"`
+}
+
+func (r Rate) String() string {
+	return Stringify(r)
+}
+
+// RateLimits represents the rate limits for the current client.
+type RateLimits struct {
+	// The rate limit for non-search API requests.  Unauthenticated
+	// requests are limited to 60 per hour.  Authenticated requests are
+	// limited to 5,000 per hour.
+	//
+	// GitHub API docs: https://developer.github.com/v3/#rate-limiting
+	Core *Rate `json:"core"`
+
+	// The rate limit for search API requests.  Unauthenticated requests
+	// are limited to 10 requests per minutes.  Authenticated requests are
+	// limited to 30 per minute.
+	//
+	// GitHub API docs: https://developer.github.com/v3/search/#rate-limit
+	Search *Rate `json:"search"`
+}
+
+func (r RateLimits) String() string {
+	return Stringify(r)
+}
+
+type rateLimitCategory uint8
+
+const (
+	coreCategory rateLimitCategory = iota
+	searchCategory
+
+	categories // An array of this length will be able to contain all rate limit categories.
+)
+
+// category returns the rate limit category of the endpoint, determined by Request.URL.Path.
+func category(path string) rateLimitCategory {
+	switch {
+	default:
+		return coreCategory
+	case strings.HasPrefix(path, "/search/"):
+		return searchCategory
+	}
+}
+
+// RateLimit returns the core rate limit for the current client.
+//
+// Deprecated: RateLimit is deprecated, use RateLimits instead.
+func (c *Client) RateLimit() (*Rate, *Response, error) {
+	limits, resp, err := c.RateLimits()
+	if limits == nil {
+		return nil, nil, err
+	}
+
+	return limits.Core, resp, err
+}
+
+// RateLimits returns the rate limits for the current client.
+func (c *Client) RateLimits() (*RateLimits, *Response, error) {
+	req, err := c.NewRequest("GET", "rate_limit", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(struct {
+		Resources *RateLimits `json:"resources"`
+	})
+	resp, err := c.Do(req, response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if response.Resources != nil {
+		c.rateMu.Lock()
+		if response.Resources.Core != nil {
+			c.rateLimits[coreCategory] = *response.Resources.Core
+		}
+		if response.Resources.Search != nil {
+			c.rateLimits[searchCategory] = *response.Resources.Search
+		}
+		c.rateMu.Unlock()
+	}
+
+	return response.Resources, resp, err
+}
+
+/*
+UnauthenticatedRateLimitedTransport allows you to make unauthenticated calls
+that need to use a higher rate limit associated with your OAuth application.
+
+	t := &github.UnauthenticatedRateLimitedTransport{
+		ClientID:     "your app's client ID",
+		ClientSecret: "your app's client secret",
+	}
+	client := github.NewClient(t.Client())
+
+This will append the querystring params client_id=xxx&client_secret=yyy to all
+requests.
+
+See http://developer.github.com/v3/#unauthenticated-rate-limited-requests for
+more information.
+*/
+type UnauthenticatedRateLimitedTransport struct {
+	// ClientID is the GitHub OAuth client ID of the current application, which
+	// can be found by selecting its entry in the list at
+	// https://github.com/settings/applications.
+	ClientID string
+
+	// ClientSecret is the GitHub OAuth client secret of the current
+	// application.
+	ClientSecret string
+
+	// Transport is the underlying HTTP transport to use when making requests.
+	// It will default to http.DefaultTransport if nil.
+	Transport http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *UnauthenticatedRateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.ClientID == "" {
+		return nil, errors.New("t.ClientID is empty")
+	}
+	if t.ClientSecret == "" {
+		return nil, errors.New("t.ClientSecret is empty")
+	}
+
+	// To set extra querystring params, we must make a copy of the Request so
+	// that we don't modify the Request we were given. This is required by the
+	// specification of http.RoundTripper.
+	req = cloneRequest(req)
+	q := req.URL.Query()
+	q.Set("client_id", t.ClientID)
+	q.Set("client_secret", t.ClientSecret)
+	req.URL.RawQuery = q.Encode()
+
+	// Make the HTTP request.
+	return t.transport().RoundTrip(req)
+}
+
+// Client returns an *http.Client that makes requests which are subject to the
+// rate limit of your OAuth application.
+func (t *UnauthenticatedRateLimitedTransport) Client() *http.Client {
+	return &http.Client{Transport: t}
+}
+
+func (t *UnauthenticatedRateLimitedTransport) transport() http.RoundTripper {
+	if t.Transport != nil {
+		return t.Transport
+	}
+	return http.DefaultTransport
+}
+
+// BasicAuthTransport is an http.RoundTripper that authenticates all requests
+// using HTTP Basic Authentication with the provided username and password.  It
+// additionally supports users who have two-factor authentication enabled on
+// their GitHub account.
+type BasicAuthTransport struct {
+	Username string // GitHub username
+	Password string // GitHub password
+	OTP      string // one-time password for users with two-factor auth enabled
+
+	// Transport is the underlying HTTP transport to use when making requests.
+	// It will default to http.DefaultTransport if nil.
+	Transport http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = cloneRequest(req) // per RoundTrip contract
+	req.SetBasicAuth(t.Username, t.Password)
+	if t.OTP != "" {
+		req.Header.Set(headerOTP, t.OTP)
+	}
+	return t.transport().RoundTrip(req)
+}
+
+// Client returns an *http.Client that makes requests that are authenticated
+// using HTTP Basic Authentication.
+func (t *BasicAuthTransport) Client() *http.Client {
+	return &http.Client{Transport: t}
+}
+
+func (t *BasicAuthTransport) transport() http.RoundTripper {
+	if t.Transport != nil {
+		return t.Transport
+	}
+	return http.DefaultTransport
+}
+
+// cloneRequest returns a clone of the provided *http.Request. The clone is a
+// shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}
+
+// Bool is a helper routine that allocates a new bool value
+// to store v and returns a pointer to it.
+func Bool(v bool) *bool { return &v }
+
+// Int is a helper routine that allocates a new int value
+// to store v and returns a pointer to it.
+func Int(v int) *int { return &v }
+
+// String is a helper routine that allocates a new string value
+// to store v and returns a pointer to it.
+func String(v string) *string { return &v }

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/gitignore.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/gitignore.go
@@ -1,0 +1,61 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// GitignoresService provides access to the gitignore related functions in the
+// GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/gitignore/
+type GitignoresService service
+
+// Gitignore represents a .gitignore file as returned by the GitHub API.
+type Gitignore struct {
+	Name   *string `json:"name,omitempty"`
+	Source *string `json:"source,omitempty"`
+}
+
+func (g Gitignore) String() string {
+	return Stringify(g)
+}
+
+// List all available Gitignore templates.
+//
+// http://developer.github.com/v3/gitignore/#listing-available-templates
+func (s GitignoresService) List() ([]string, *Response, error) {
+	req, err := s.client.NewRequest("GET", "gitignore/templates", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	availableTemplates := new([]string)
+	resp, err := s.client.Do(req, availableTemplates)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *availableTemplates, resp, err
+}
+
+// Get a Gitignore by name.
+//
+// http://developer.github.com/v3/gitignore/#get-a-single-template
+func (s GitignoresService) Get(name string) (*Gitignore, *Response, error) {
+	u := fmt.Sprintf("gitignore/templates/%v", name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gitignore := new(Gitignore)
+	resp, err := s.client.Do(req, gitignore)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gitignore, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues.go
@@ -1,0 +1,299 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// IssuesService handles communication with the issue related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/
+type IssuesService service
+
+// Issue represents a GitHub issue on a repository.
+type Issue struct {
+	ID               *int              `json:"id,omitempty"`
+	Number           *int              `json:"number,omitempty"`
+	State            *string           `json:"state,omitempty"`
+	Title            *string           `json:"title,omitempty"`
+	Body             *string           `json:"body,omitempty"`
+	User             *User             `json:"user,omitempty"`
+	Labels           []Label           `json:"labels,omitempty"`
+	Assignee         *User             `json:"assignee,omitempty"`
+	Comments         *int              `json:"comments,omitempty"`
+	ClosedAt         *time.Time        `json:"closed_at,omitempty"`
+	CreatedAt        *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time        `json:"updated_at,omitempty"`
+	URL              *string           `json:"url,omitempty"`
+	HTMLURL          *string           `json:"html_url,omitempty"`
+	Milestone        *Milestone        `json:"milestone,omitempty"`
+	PullRequestLinks *PullRequestLinks `json:"pull_request,omitempty"`
+	Repository       *Repository       `json:"repository,omitempty"`
+	Reactions        *Reactions        `json:"reactions,omitempty"`
+	Assignees        []*User           `json:"assignees,omitempty"`
+
+	// TextMatches is only populated from search results that request text matches
+	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
+	TextMatches []TextMatch `json:"text_matches,omitempty"`
+}
+
+func (i Issue) String() string {
+	return Stringify(i)
+}
+
+// IssueRequest represents a request to create/edit an issue.
+// It is separate from Issue above because otherwise Labels
+// and Assignee fail to serialize to the correct JSON.
+type IssueRequest struct {
+	Title     *string   `json:"title,omitempty"`
+	Body      *string   `json:"body,omitempty"`
+	Labels    *[]string `json:"labels,omitempty"`
+	Assignee  *string   `json:"assignee,omitempty"`
+	State     *string   `json:"state,omitempty"`
+	Milestone *int      `json:"milestone,omitempty"`
+	Assignees *[]string `json:"assignees,omitempty"`
+}
+
+// IssueListOptions specifies the optional parameters to the IssuesService.List
+// and IssuesService.ListByOrg methods.
+type IssueListOptions struct {
+	// Filter specifies which issues to list.  Possible values are: assigned,
+	// created, mentioned, subscribed, all.  Default is "assigned".
+	Filter string `url:"filter,omitempty"`
+
+	// State filters issues based on their state.  Possible values are: open,
+	// closed, all.  Default is "open".
+	State string `url:"state,omitempty"`
+
+	// Labels filters issues based on their label.
+	Labels []string `url:"labels,comma,omitempty"`
+
+	// Sort specifies how to sort issues.  Possible values are: created, updated,
+	// and comments.  Default value is "created".
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort issues.  Possible values are: asc, desc.
+	// Default is "desc".
+	Direction string `url:"direction,omitempty"`
+
+	// Since filters issues by time.
+	Since time.Time `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// PullRequestLinks object is added to the Issue object when it's an issue included
+// in the IssueCommentEvent webhook payload, if the webhooks is fired by a comment on a PR
+type PullRequestLinks struct {
+	URL      *string `json:"url,omitempty"`
+	HTMLURL  *string `json:"html_url,omitempty"`
+	DiffURL  *string `json:"diff_url,omitempty"`
+	PatchURL *string `json:"patch_url,omitempty"`
+}
+
+// List the issues for the authenticated user.  If all is true, list issues
+// across all the user's visible repositories including owned, member, and
+// organization repositories; if false, list only owned and member
+// repositories.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#list-issues
+func (s *IssuesService) List(all bool, opt *IssueListOptions) ([]*Issue, *Response, error) {
+	var u string
+	if all {
+		u = "issues"
+	} else {
+		u = "user/issues"
+	}
+	return s.listIssues(u, opt)
+}
+
+// ListByOrg fetches the issues in the specified organization for the
+// authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#list-issues
+func (s *IssuesService) ListByOrg(org string, opt *IssueListOptions) ([]*Issue, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/issues", org)
+	return s.listIssues(u, opt)
+}
+
+func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]*Issue, *Response, error) {
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	issues := new([]*Issue)
+	resp, err := s.client.Do(req, issues)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *issues, resp, err
+}
+
+// IssueListByRepoOptions specifies the optional parameters to the
+// IssuesService.ListByRepo method.
+type IssueListByRepoOptions struct {
+	// Milestone limits issues for the specified milestone.  Possible values are
+	// a milestone number, "none" for issues with no milestone, "*" for issues
+	// with any milestone.
+	Milestone string `url:"milestone,omitempty"`
+
+	// State filters issues based on their state.  Possible values are: open,
+	// closed, all.  Default is "open".
+	State string `url:"state,omitempty"`
+
+	// Assignee filters issues based on their assignee.  Possible values are a
+	// user name, "none" for issues that are not assigned, "*" for issues with
+	// any assigned user.
+	Assignee string `url:"assignee,omitempty"`
+
+	// Creator filters issues based on their creator.
+	Creator string `url:"creator,omitempty"`
+
+	// Mentioned filters issues to those mentioned a specific user.
+	Mentioned string `url:"mentioned,omitempty"`
+
+	// Labels filters issues based on their label.
+	Labels []string `url:"labels,omitempty,comma"`
+
+	// Sort specifies how to sort issues.  Possible values are: created, updated,
+	// and comments.  Default value is "created".
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort issues.  Possible values are: asc, desc.
+	// Default is "desc".
+	Direction string `url:"direction,omitempty"`
+
+	// Since filters issues by time.
+	Since time.Time `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListByRepo lists the issues for the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#list-issues-for-a-repository
+func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRepoOptions) ([]*Issue, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	issues := new([]*Issue)
+	resp, err := s.client.Do(req, issues)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *issues, resp, err
+}
+
+// Get a single issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#get-a-single-issue
+func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	issue := new(Issue)
+	resp, err := s.client.Do(req, issue)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return issue, resp, err
+}
+
+// Create a new issue on the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#create-an-issue
+func (s *IssuesService) Create(owner string, repo string, issue *IssueRequest) (*Issue, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
+	req, err := s.client.NewRequest("POST", u, issue)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// Edit an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/#edit-an-issue
+func (s *IssuesService) Edit(owner string, repo string, number int, issue *IssueRequest) (*Issue, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d", owner, repo, number)
+	req, err := s.client.NewRequest("PATCH", u, issue)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// Lock an issue's conversation.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/#lock-an-issue
+func (s *IssuesService) Lock(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Unlock an issue's conversation.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/#unlock-an-issue
+func (s *IssuesService) Unlock(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/lock", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_assignees.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_assignees.go
@@ -1,0 +1,82 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ListAssignees fetches all available assignees (owners and collaborators) to
+// which issues may be assigned.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/assignees/#list-assignees
+func (s *IssuesService) ListAssignees(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/assignees", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	assignees := new([]*User)
+	resp, err := s.client.Do(req, assignees)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *assignees, resp, err
+}
+
+// IsAssignee checks if a user is an assignee for the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/assignees/#check-assignee
+func (s *IssuesService) IsAssignee(owner, repo, user string) (bool, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/assignees/%v", owner, repo, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	assignee, err := parseBoolResponse(err)
+	return assignee, resp, err
+}
+
+// AddAssignees adds the provided GitHub users as assignees to the issue.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
+func (s *IssuesService) AddAssignees(owner, repo string, number int, assignees []string) (*Issue, *Response, error) {
+	users := &struct {
+		Assignees []string `json:"assignees,omitempty"`
+	}{Assignees: assignees}
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, users)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issue := &Issue{}
+	resp, err := s.client.Do(req, issue)
+	return issue, resp, err
+}
+
+// RemoveAssignees removes the provided GitHub users as assignees from the issue.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
+func (s *IssuesService) RemoveAssignees(owner, repo string, number int, assignees []string) (*Issue, *Response, error) {
+	users := &struct {
+		Assignees []string `json:"assignees,omitempty"`
+	}{Assignees: assignees}
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/assignees", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, users)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issue := &Issue{}
+	resp, err := s.client.Do(req, issue)
+	return issue, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_comments.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_comments.go
@@ -1,0 +1,147 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// IssueComment represents a comment left on an issue.
+type IssueComment struct {
+	ID        *int       `json:"id,omitempty"`
+	Body      *string    `json:"body,omitempty"`
+	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	HTMLURL   *string    `json:"html_url,omitempty"`
+	IssueURL  *string    `json:"issue_url,omitempty"`
+}
+
+func (i IssueComment) String() string {
+	return Stringify(i)
+}
+
+// IssueListCommentsOptions specifies the optional parameters to the
+// IssuesService.ListComments method.
+type IssueListCommentsOptions struct {
+	// Sort specifies how to sort comments.  Possible values are: created, updated.
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort comments.  Possible values are: asc, desc.
+	Direction string `url:"direction,omitempty"`
+
+	// Since filters comments by time.
+	Since time.Time `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListComments lists all comments on the specified issue.  Specifying an issue
+// number of 0 will return all comments on all issues for the repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
+func (s *IssuesService) ListComments(owner string, repo string, number int, opt *IssueListCommentsOptions) ([]*IssueComment, *Response, error) {
+	var u string
+	if number == 0 {
+		u = fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
+	} else {
+		u = fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comments := new([]*IssueComment)
+	resp, err := s.client.Do(req, comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *comments, resp, err
+}
+
+// GetComment fetches the specified issue comment.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/comments/#get-a-single-comment
+func (s *IssuesService) GetComment(owner string, repo string, id int) (*IssueComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comment := new(IssueComment)
+	resp, err := s.client.Do(req, comment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return comment, resp, err
+}
+
+// CreateComment creates a new comment on the specified issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/comments/#create-a-comment
+func (s *IssuesService) CreateComment(owner string, repo string, number int, comment *IssueComment) (*IssueComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/comments", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+	c := new(IssueComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// EditComment updates an issue comment.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/comments/#edit-a-comment
+func (s *IssuesService) EditComment(owner string, repo string, id int, comment *IssueComment) (*IssueComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+	c := new(IssueComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// DeleteComment deletes an issue comment.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/comments/#delete-a-comment
+func (s *IssuesService) DeleteComment(owner string, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%d", owner, repo, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_events.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_events.go
@@ -1,0 +1,149 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// IssueEvent represents an event that occurred around an Issue or Pull Request.
+type IssueEvent struct {
+	ID  *int    `json:"id,omitempty"`
+	URL *string `json:"url,omitempty"`
+
+	// The User that generated this event.
+	Actor *User `json:"actor,omitempty"`
+
+	// Event identifies the actual type of Event that occurred.  Possible
+	// values are:
+	//
+	//     closed
+	//       The Actor closed the issue.
+	//       If the issue was closed by commit message, CommitID holds the SHA1 hash of the commit.
+	//
+	//     merged
+	//       The Actor merged into master a branch containing a commit mentioning the issue.
+	//       CommitID holds the SHA1 of the merge commit.
+	//
+	//     referenced
+	//       The Actor committed to master a commit mentioning the issue in its commit message.
+	//       CommitID holds the SHA1 of the commit.
+	//
+	//     reopened, locked, unlocked
+	//       The Actor did that to the issue.
+	//
+	//     renamed
+	//       The Actor changed the issue title from Rename.From to Rename.To.
+	//
+	//     mentioned
+	//       Someone unspecified @mentioned the Actor [sic] in an issue comment body.
+	//
+	//     assigned, unassigned
+	//       The Actor assigned the issue to or removed the assignment from the Assignee.
+	//
+	//     labeled, unlabeled
+	//       The Actor added or removed the Label from the issue.
+	//
+	//     milestoned, demilestoned
+	//       The Actor added or removed the issue from the Milestone.
+	//
+	//     subscribed, unsubscribed
+	//       The Actor subscribed to or unsubscribed from notifications for an issue.
+	//
+	//     head_ref_deleted, head_ref_restored
+	//       The pull request’s branch was deleted or restored.
+	//
+	Event *string `json:"event,omitempty"`
+
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	Issue     *Issue     `json:"issue,omitempty"`
+
+	// Only present on certain events; see above.
+	Assignee  *User      `json:"assignee,omitempty"`
+	CommitID  *string    `json:"commit_id,omitempty"`
+	Milestone *Milestone `json:"milestone,omitempty"`
+	Label     *Label     `json:"label,omitempty"`
+	Rename    *Rename    `json:"rename,omitempty"`
+}
+
+// ListIssueEvents lists events for the specified issue.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/events/#list-events-for-an-issue
+func (s *IssuesService) ListIssueEvents(owner, repo string, number int, opt *ListOptions) ([]*IssueEvent, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/events", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var events []*IssueEvent
+	resp, err := s.client.Do(req, &events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return events, resp, err
+}
+
+// ListRepositoryEvents lists events for the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/events/#list-events-for-a-repository
+func (s *IssuesService) ListRepositoryEvents(owner, repo string, opt *ListOptions) ([]*IssueEvent, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var events []*IssueEvent
+	resp, err := s.client.Do(req, &events)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return events, resp, err
+}
+
+// GetEvent returns the specified issue event.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/events/#get-a-single-event
+func (s *IssuesService) GetEvent(owner, repo string, id int) (*IssueEvent, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/events/%v", owner, repo, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	event := new(IssueEvent)
+	resp, err := s.client.Do(req, event)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return event, resp, err
+}
+
+// Rename contains details for 'renamed' events.
+type Rename struct {
+	From *string `json:"from,omitempty"`
+	To   *string `json:"to,omitempty"`
+}
+
+func (r Rename) String() string {
+	return Stringify(r)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_labels.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_labels.go
@@ -1,0 +1,222 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Label represents a GitHub label on an Issue
+type Label struct {
+	URL   *string `json:"url,omitempty"`
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
+}
+
+func (l Label) String() string {
+	return fmt.Sprint(*l.Name)
+}
+
+// ListLabels lists all labels for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
+func (s *IssuesService) ListLabels(owner string, repo string, opt *ListOptions) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	labels := new([]*Label)
+	resp, err := s.client.Do(req, labels)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *labels, resp, err
+}
+
+// GetLabel gets a single label.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#get-a-single-label
+func (s *IssuesService) GetLabel(owner string, repo string, name string) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	label := new(Label)
+	resp, err := s.client.Do(req, label)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return label, resp, err
+}
+
+// CreateLabel creates a new label on the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#create-a-label
+func (s *IssuesService) CreateLabel(owner string, repo string, label *Label) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels", owner, repo)
+	req, err := s.client.NewRequest("POST", u, label)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(Label)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// EditLabel edits a label.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#update-a-label
+func (s *IssuesService) EditLabel(owner string, repo string, name string, label *Label) (*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	req, err := s.client.NewRequest("PATCH", u, label)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(Label)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// DeleteLabel deletes a label.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#delete-a-label
+func (s *IssuesService) DeleteLabel(owner string, repo string, name string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/labels/%v", owner, repo, name)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ListLabelsByIssue lists all labels for an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
+func (s *IssuesService) ListLabelsByIssue(owner string, repo string, number int, opt *ListOptions) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	labels := new([]*Label)
+	resp, err := s.client.Do(req, labels)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *labels, resp, err
+}
+
+// AddLabelsToIssue adds labels to an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
+func (s *IssuesService) AddLabelsToIssue(owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, labels)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new([]*Label)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *l, resp, err
+}
+
+// RemoveLabelForIssue removes a label for an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
+func (s *IssuesService) RemoveLabelForIssue(owner string, repo string, number int, label string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels/%v", owner, repo, number, label)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ReplaceLabelsForIssue replaces all labels for an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
+func (s *IssuesService) ReplaceLabelsForIssue(owner string, repo string, number int, labels []string) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	req, err := s.client.NewRequest("PUT", u, labels)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new([]*Label)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *l, resp, err
+}
+
+// RemoveLabelsForIssue removes all labels for an issue.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue
+func (s *IssuesService) RemoveLabelsForIssue(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%d/labels", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ListLabelsForMilestone lists labels for every issue in a milestone.
+//
+// GitHub API docs: http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone
+func (s *IssuesService) ListLabelsForMilestone(owner string, repo string, number int, opt *ListOptions) ([]*Label, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones/%d/labels", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	labels := new([]*Label)
+	resp, err := s.client.Do(req, labels)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *labels, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_milestones.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_milestones.go
@@ -1,0 +1,146 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// Milestone represents a Github repository milestone.
+type Milestone struct {
+	URL          *string    `json:"url,omitempty"`
+	HTMLURL      *string    `json:"html_url,omitempty"`
+	LabelsURL    *string    `json:"labels_url,omitempty"`
+	ID           *int       `json:"id,omitempty"`
+	Number       *int       `json:"number,omitempty"`
+	State        *string    `json:"state,omitempty"`
+	Title        *string    `json:"title,omitempty"`
+	Description  *string    `json:"description,omitempty"`
+	Creator      *User      `json:"creator,omitempty"`
+	OpenIssues   *int       `json:"open_issues,omitempty"`
+	ClosedIssues *int       `json:"closed_issues,omitempty"`
+	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	ClosedAt     *time.Time `json:"closed_at,omitempty"`
+	DueOn        *time.Time `json:"due_on,omitempty"`
+}
+
+func (m Milestone) String() string {
+	return Stringify(m)
+}
+
+// MilestoneListOptions specifies the optional parameters to the
+// IssuesService.ListMilestones method.
+type MilestoneListOptions struct {
+	// State filters milestones based on their state. Possible values are:
+	// open, closed. Default is "open".
+	State string `url:"state,omitempty"`
+
+	// Sort specifies how to sort milestones. Possible values are: due_date, completeness.
+	// Default value is "due_date".
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort milestones. Possible values are: asc, desc.
+	// Default is "asc".
+	Direction string `url:"direction,omitempty"`
+
+	ListOptions
+}
+
+// ListMilestones lists all milestones for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+func (s *IssuesService) ListMilestones(owner string, repo string, opt *MilestoneListOptions) ([]*Milestone, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	milestones := new([]*Milestone)
+	resp, err := s.client.Do(req, milestones)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *milestones, resp, err
+}
+
+// GetMilestone gets a single milestone.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+func (s *IssuesService) GetMilestone(owner string, repo string, number int) (*Milestone, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	milestone := new(Milestone)
+	resp, err := s.client.Do(req, milestone)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return milestone, resp, err
+}
+
+// CreateMilestone creates a new milestone on the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/milestones/#create-a-milestone
+func (s *IssuesService) CreateMilestone(owner string, repo string, milestone *Milestone) (*Milestone, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones", owner, repo)
+	req, err := s.client.NewRequest("POST", u, milestone)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(Milestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// EditMilestone edits a milestone.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/milestones/#update-a-milestone
+func (s *IssuesService) EditMilestone(owner string, repo string, number int, milestone *Milestone) (*Milestone, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	req, err := s.client.NewRequest("PATCH", u, milestone)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(Milestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// DeleteMilestone deletes a milestone.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/milestones/#delete-a-milestone
+func (s *IssuesService) DeleteMilestone(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/milestones/%d", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_timeline.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/issues_timeline.go
@@ -1,0 +1,148 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// Timeline represents an event that occurred around an Issue or Pull Request.
+//
+// It is similar to an IssueEvent but may contain more information.
+// GitHub API docs: https://developer.github.com/v3/issues/timeline/
+type Timeline struct {
+	ID        *int    `json:"id,omitempty"`
+	URL       *string `json:"url,omitempty"`
+	CommitURL *string `json:"commit_url,omitempty"`
+
+	// The User object that generated the event.
+	Actor *User `json:"actor,omitempty"`
+
+	// Event identifies the actual type of Event that occurred. Possible values
+	// are:
+	//
+	//     assigned
+	//       The issue was assigned to the assignee.
+	//
+	//     closed
+	//       The issue was closed by the actor. When the commit_id is present, it
+	//       identifies the commit that closed the issue using "closes / fixes #NN"
+	//       syntax.
+	//
+	//     commented
+	//       A comment was added to the issue.
+	//
+	//     committed
+	//       A commit was added to the pull request's 'HEAD' branch. Only provided
+	//       for pull requests.
+	//
+	//     cross-referenced
+	//       The issue was referenced from another issue. The 'source' attribute
+	//       contains the 'id', 'actor', and 'url' of the reference's source.
+	//
+	//     demilestoned
+	//       The issue was removed from a milestone.
+	//
+	//     head_ref_deleted
+	//       The pull request's branch was deleted.
+	//
+	//     head_ref_restored
+	//       The pull request's branch was restored.
+	//
+	//     labeled
+	//       A label was added to the issue.
+	//
+	//     locked
+	//       The issue was locked by the actor.
+	//
+	//     mentioned
+	//       The actor was @mentioned in an issue body.
+	//
+	//     merged
+	//       The issue was merged by the actor. The 'commit_id' attribute is the
+	//       SHA1 of the HEAD commit that was merged.
+	//
+	//     milestoned
+	//       The issue was added to a milestone.
+	//
+	//     referenced
+	//       The issue was referenced from a commit message. The 'commit_id'
+	//       attribute is the commit SHA1 of where that happened.
+	//
+	//     renamed
+	//       The issue title was changed.
+	//
+	//     reopened
+	//       The issue was reopened by the actor.
+	//
+	//     subscribed
+	//       The actor subscribed to receive notifications for an issue.
+	//
+	//     unassigned
+	//       The assignee was unassigned from the issue.
+	//
+	//     unlabeled
+	//       A label was removed from the issue.
+	//
+	//     unlocked
+	//       The issue was unlocked by the actor.
+	//
+	//     unsubscribed
+	//       The actor unsubscribed to stop receiving notifications for an issue.
+	//
+	Event *string `json:"event,omitempty"`
+
+	// The string SHA of a commit that referenced this Issue or Pull Request.
+	CommitID *string `json:"commit_id,omitempty"`
+	// The timestamp indicating when the event occurred.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	// The Label object including `name` and `color` attributes. Only provided for
+	// 'labeled' and 'unlabeled' events.
+	Label *Label `json:"label,omitempty"`
+	// The User object which was assigned to (or unassigned from) this Issue or
+	// Pull Request. Only provided for 'assigned' and 'unassigned' events.
+	Assignee *User `json:"assignee,omitempty"`
+	// The Milestone object including a 'title' attribute.
+	// Only provided for 'milestoned' and 'demilestoned' events.
+	Milestone *Milestone `json:"milestone,omitempty"`
+	// The 'id', 'actor', and 'url' for the source of a reference from another issue.
+	// Only provided for 'cross-referenced' events.
+	Source *Source `json:"source,omitempty"`
+	// An object containing rename details including 'from' and 'to' attributes.
+	// Only provided for 'renamed' events.
+	Rename *Rename `json:"rename,omitempty"`
+}
+
+// Source represents a reference's source.
+type Source struct {
+	ID    *int    `json:"id,omitempty"`
+	URL   *string `json:"url,omitempty"`
+	Actor *User   `json:"actor,omitempty"`
+}
+
+// ListIssueTimeline lists events for the specified issue.
+//
+// GitHub API docs: https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
+func (s *IssuesService) ListIssueTimeline(owner, repo string, number int, opt *ListOptions) ([]*Timeline, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/timeline", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTimelinePreview)
+
+	var events []*Timeline
+	resp, err := s.client.Do(req, &events)
+	return events, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/licenses.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/licenses.go
@@ -1,0 +1,79 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// LicensesService handles communication with the license related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/pulls/
+type LicensesService service
+
+// License represents an open source license.
+type License struct {
+	Key  *string `json:"key,omitempty"`
+	Name *string `json:"name,omitempty"`
+	URL  *string `json:"url,omitempty"`
+
+	HTMLURL        *string   `json:"html_url,omitempty"`
+	Featured       *bool     `json:"featured,omitempty"`
+	Description    *string   `json:"description,omitempty"`
+	Category       *string   `json:"category,omitempty"`
+	Implementation *string   `json:"implementation,omitempty"`
+	Required       *[]string `json:"required,omitempty"`
+	Permitted      *[]string `json:"permitted,omitempty"`
+	Forbidden      *[]string `json:"forbidden,omitempty"`
+	Body           *string   `json:"body,omitempty"`
+}
+
+func (l License) String() string {
+	return Stringify(l)
+}
+
+// List popular open source licenses.
+//
+// GitHub API docs: https://developer.github.com/v3/licenses/#list-all-licenses
+func (s *LicensesService) List() ([]*License, *Response, error) {
+	req, err := s.client.NewRequest("GET", "licenses", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	licenses := new([]*License)
+	resp, err := s.client.Do(req, licenses)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *licenses, resp, err
+}
+
+// Get extended metadata for one license.
+//
+// GitHub API docs: https://developer.github.com/v3/licenses/#get-an-individual-license
+func (s *LicensesService) Get(licenseName string) (*License, *Response, error) {
+	u := fmt.Sprintf("licenses/%s", licenseName)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	license := new(License)
+	resp, err := s.client.Do(req, license)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return license, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/messages.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/messages.go
@@ -1,0 +1,190 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file provides functions for validating payloads from GitHub Webhooks.
+// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	// sha1Prefix is the prefix used by GitHub before the HMAC hexdigest.
+	sha1Prefix = "sha1"
+	// sha256Prefix and sha512Prefix are provided for future compatibility.
+	sha256Prefix = "sha256"
+	sha512Prefix = "sha512"
+	// signatureHeader is the GitHub header key used to pass the HMAC hexdigest.
+	signatureHeader = "X-Hub-Signature"
+	// eventTypeHeader is the Github header key used to pass the event type.
+	eventTypeHeader = "X-Github-Event"
+)
+
+var (
+	// eventTypeMapping maps webhooks types to their corresponding go-github struct types.
+	eventTypeMapping = map[string]string{
+		"commit_comment":                        "CommitCommentEvent",
+		"create":                                "CreateEvent",
+		"delete":                                "DeleteEvent",
+		"deployment":                            "DeploymentEvent",
+		"deployment_status":                     "DeploymentStatusEvent",
+		"fork":                                  "ForkEvent",
+		"gollum":                                "GollumEvent",
+		"integration_installation":              "IntegrationInstallationEvent",
+		"integration_installation_repositories": "IntegrationInstallationRepositoriesEvent",
+		"issue_comment":                         "IssueCommentEvent",
+		"issues":                                "IssuesEvent",
+		"member":                                "MemberEvent",
+		"membership":                            "MembershipEvent",
+		"page_build":                            "PageBuildEvent",
+		"public":                                "PublicEvent",
+		"pull_request_review_comment":           "PullRequestReviewCommentEvent",
+		"pull_request":                          "PullRequestEvent",
+		"push":                                  "PushEvent",
+		"repository":                            "RepositoryEvent",
+		"release":                               "ReleaseEvent",
+		"status":                                "StatusEvent",
+		"team_add":                              "TeamAddEvent",
+		"watch":                                 "WatchEvent",
+	}
+)
+
+// genMAC generates the HMAC signature for a message provided the secret key
+// and hashFunc.
+func genMAC(message, key []byte, hashFunc func() hash.Hash) []byte {
+	mac := hmac.New(hashFunc, key)
+	mac.Write(message)
+	return mac.Sum(nil)
+}
+
+// checkMAC reports whether messageMAC is a valid HMAC tag for message.
+func checkMAC(message, messageMAC, key []byte, hashFunc func() hash.Hash) bool {
+	expectedMAC := genMAC(message, key, hashFunc)
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// messageMAC returns the hex-decoded HMAC tag from the signature and its
+// corresponding hash function.
+func messageMAC(signature string) ([]byte, func() hash.Hash, error) {
+	if signature == "" {
+		return nil, nil, errors.New("missing signature")
+	}
+	sigParts := strings.SplitN(signature, "=", 2)
+	if len(sigParts) != 2 {
+		return nil, nil, fmt.Errorf("error parsing signature %q", signature)
+	}
+
+	var hashFunc func() hash.Hash
+	switch sigParts[0] {
+	case sha1Prefix:
+		hashFunc = sha1.New
+	case sha256Prefix:
+		hashFunc = sha256.New
+	case sha512Prefix:
+		hashFunc = sha512.New
+	default:
+		return nil, nil, fmt.Errorf("unknown hash type prefix: %q", sigParts[0])
+	}
+
+	buf, err := hex.DecodeString(sigParts[1])
+	if err != nil {
+		return nil, nil, fmt.Errorf("error decoding signature %q: %v", signature, err)
+	}
+	return buf, hashFunc, nil
+}
+
+// ValidatePayload validates an incoming GitHub Webhook event request
+// and returns the (JSON) payload.
+// secretKey is the GitHub Webhook secret message.
+//
+// Example usage:
+//
+//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//       payload, err := github.ValidatePayload(r, s.webhookSecretKey)
+//       if err != nil { ... }
+//       // Process payload...
+//     }
+//
+func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err error) {
+	payload, err = ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	sig := r.Header.Get(signatureHeader)
+	if err := validateSignature(sig, payload, secretKey); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// validateSignature validates the signature for the given payload.
+// signature is the GitHub hash signature delivered in the X-Hub-Signature header.
+// payload is the JSON payload sent by GitHub Webhooks.
+// secretKey is the GitHub Webhook secret message.
+//
+// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+func validateSignature(signature string, payload, secretKey []byte) error {
+	messageMAC, hashFunc, err := messageMAC(signature)
+	if err != nil {
+		return err
+	}
+	if !checkMAC(payload, messageMAC, secretKey, hashFunc) {
+		return errors.New("payload signature check failed")
+	}
+	return nil
+}
+
+// WebHookType returns the event type of webhook request r.
+func WebHookType(r *http.Request) string {
+	return r.Header.Get(eventTypeHeader)
+}
+
+// ParseWebHook parses the event payload. For recognized event types, a
+// value of the corresponding struct type will be returned (as returned
+// by Event.Payload()). An error will be returned for unrecognized event
+// types.
+//
+// Example usage:
+//
+//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//       payload, err := github.ValidatePayload(r, s.webhookSecretKey)
+//       if err != nil { ... }
+//       event, err := github.ParseWebHook(github.WebHookType(r), payload)
+//       if err != nil { ... }
+//       switch event := event.(type) {
+//       case CommitCommentEvent:
+//           processCommitCommentEvent(event)
+//       case CreateEvent:
+//           processCreateEvent(event)
+//       ...
+//       }
+//     }
+//
+func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
+	eventType, ok := eventTypeMapping[messageType]
+	if !ok {
+		return nil, fmt.Errorf("unknown X-Github-Event in message: %v", messageType)
+	}
+
+	event := Event{
+		Type:       &eventType,
+		RawPayload: (*json.RawMessage)(&payload),
+	}
+	return event.Payload(), nil
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/migrations.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/migrations.go
@@ -1,0 +1,223 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// MigrationService provides access to the migration related functions
+// in the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/
+type MigrationService service
+
+// Migration represents a GitHub migration (archival).
+type Migration struct {
+	ID   *int    `json:"id,omitempty"`
+	GUID *string `json:"guid,omitempty"`
+	// State is the current state of a migration.
+	// Possible values are:
+	//     "pending" which means the migration hasn't started yet,
+	//     "exporting" which means the migration is in progress,
+	//     "exported" which means the migration finished successfully, or
+	//     "failed" which means the migration failed.
+	State *string `json:"state,omitempty"`
+	// LockRepositories indicates whether repositories are locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories *bool `json:"lock_repositories,omitempty"`
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments *bool         `json:"exclude_attachments,omitempty"`
+	URL                *string       `json:"url,omitempty"`
+	CreatedAt          *string       `json:"created_at,omitempty"`
+	UpdatedAt          *string       `json:"updated_at,omitempty"`
+	Repositories       []*Repository `json:"repositories,omitempty"`
+}
+
+func (m Migration) String() string {
+	return Stringify(m)
+}
+
+// MigrationOptions specifies the optional parameters to Migration methods.
+type MigrationOptions struct {
+	// LockRepositories indicates whether repositories should be locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories bool
+
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments bool
+}
+
+// startMigration represents the body of a StartMigration request.
+type startMigration struct {
+	// Repositories is a slice of repository names to migrate.
+	Repositories []string `json:"repositories,omitempty"`
+
+	// LockRepositories indicates whether repositories should be locked (to prevent
+	// manipulation) while migrating data.
+	LockRepositories *bool `json:"lock_repositories,omitempty"`
+
+	// ExcludeAttachments indicates whether attachments should be excluded from
+	// the migration (to reduce migration archive file size).
+	ExcludeAttachments *bool `json:"exclude_attachments,omitempty"`
+}
+
+// StartMigration starts the generation of a migration archive.
+// repos is a slice of repository names to migrate.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#start-a-migration
+func (s *MigrationService) StartMigration(org string, repos []string, opt *MigrationOptions) (*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations", org)
+
+	body := &startMigration{Repositories: repos}
+	if opt != nil {
+		body.LockRepositories = Bool(opt.LockRepositories)
+		body.ExcludeAttachments = Bool(opt.ExcludeAttachments)
+	}
+
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	m := &Migration{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListMigrations lists the most recent migrations.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#get-a-list-of-migrations
+func (s *MigrationService) ListMigrations(org string) ([]*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	var m []*Migration
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// MigrationStatus gets the status of a specific migration archive.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#get-the-status-of-a-migration
+func (s *MigrationService) MigrationStatus(org string, id int) (*Migration, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v", org, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	m := &Migration{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// MigrationArchiveURL fetches a migration archive URL.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#download-a-migration-archive
+func (s *MigrationService) MigrationArchiveURL(org string, id int) (url string, err error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	s.client.clientMu.Lock()
+	defer s.client.clientMu.Unlock()
+
+	// Disable the redirect mechanism because AWS fails if the GitHub auth token is provided.
+	var loc string
+	saveRedirect := s.client.client.CheckRedirect
+	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		loc = req.URL.String()
+		return errors.New("disable redirect")
+	}
+	defer func() { s.client.client.CheckRedirect = saveRedirect }()
+
+	_, err = s.client.Do(req, nil) // expect error from disable redirect
+	if err == nil {
+		return "", errors.New("expected redirect, none provided")
+	}
+	if !strings.Contains(err.Error(), "disable redirect") {
+		return "", err
+	}
+	return loc, nil
+}
+
+// DeleteMigration deletes a previous migration archive.
+// id is the migration ID.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#delete-a-migration-archive
+func (s *MigrationService) DeleteMigration(org string, id int) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/archive", org, id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// UnlockRepo unlocks a repository that was locked for migration.
+// id is the migration ID.
+// You should unlock each migrated repository and delete them when the migration
+// is complete and you no longer need the source data.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/migrations/#unlock-a-repository
+func (s *MigrationService) UnlockRepo(org string, id int, repo string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/migrations/%v/repos/%v/lock", org, id, repo)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMigrationsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/migrations_source_import.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/migrations_source_import.go
@@ -1,0 +1,326 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Import represents a repository import request.
+type Import struct {
+	// The URL of the originating repository.
+	VCSURL *string `json:"vcs_url,omitempty"`
+	// The originating VCS type. Can be one of 'subversion', 'git',
+	// 'mercurial', or 'tfvc'. Without this parameter, the import job will
+	// take additional time to detect the VCS type before beginning the
+	// import. This detection step will be reflected in the response.
+	VCS *string `json:"vcs,omitempty"`
+	// VCSUsername and VCSPassword are only used for StartImport calls that
+	// are importing a password-protected repository.
+	VCSUsername *string `json:"vcs_username,omitempty"`
+	VCSPassword *string `json:"vcs_password,omitempty"`
+	// For a tfvc import, the name of the project that is being imported.
+	TFVCProject *string `json:"tfvc_project,omitempty"`
+
+	// LFS related fields that may be preset in the Import Progress response
+
+	// Describes whether the import has been opted in or out of using Git
+	// LFS. The value can be 'opt_in', 'opt_out', or 'undecided' if no
+	// action has been taken.
+	UseLFS *string `json:"use_lfs,omitempty"`
+	// Describes whether files larger than 100MB were found during the
+	// importing step.
+	HasLargeFiles *bool `json:"has_large_files,omitempty"`
+	// The total size in gigabytes of files larger than 100MB found in the
+	// originating repository.
+	LargeFilesSize *int `json:"large_files_size,omitempty"`
+	// The total number of files larger than 100MB found in the originating
+	// repository. To see a list of these files, call LargeFiles.
+	LargeFilesCount *int `json:"large_files_count,omitempty"`
+
+	// Identifies the current status of an import.  An import that does not
+	// have errors will progress through these steps:
+	//
+	//     detecting - the "detection" step of the import is in progress
+	//         because the request did not include a VCS parameter. The
+	//         import is identifying the type of source control present at
+	//         the URL.
+	//     importing - the "raw" step of the import is in progress. This is
+	//         where commit data is fetched from the original repository.
+	//         The import progress response will include CommitCount (the
+	//         total number of raw commits that will be imported) and
+	//         Percent (0 - 100, the current progress through the import).
+	//     mapping - the "rewrite" step of the import is in progress. This
+	//         is where SVN branches are converted to Git branches, and
+	//         where author updates are applied. The import progress
+	//         response does not include progress information.
+	//     pushing - the "push" step of the import is in progress. This is
+	//         where the importer updates the repository on GitHub. The
+	//         import progress response will include PushPercent, which is
+	//         the percent value reported by git push when it is "Writing
+	//         objects".
+	//     complete - the import is complete, and the repository is ready
+	//         on GitHub.
+	//
+	// If there are problems, you will see one of these in the status field:
+	//
+	//     auth_failed - the import requires authentication in order to
+	//         connect to the original repository. Make an UpdateImport
+	//         request, and include VCSUsername and VCSPassword.
+	//     error - the import encountered an error. The import progress
+	//         response will include the FailedStep and an error message.
+	//         Contact GitHub support for more information.
+	//     detection_needs_auth - the importer requires authentication for
+	//         the originating repository to continue detection. Make an
+	//         UpdatImport request, and include VCSUsername and
+	//         VCSPassword.
+	//     detection_found_nothing - the importer didn't recognize any
+	//         source control at the URL.
+	//     detection_found_multiple - the importer found several projects
+	//         or repositories at the provided URL. When this is the case,
+	//         the Import Progress response will also include a
+	//         ProjectChoices field with the possible project choices as
+	//         values. Make an UpdateImport request, and include VCS and
+	//         (if applicable) TFVCProject.
+	Status        *string `json:"status,omitempty"`
+	CommitCount   *int    `json:"commit_count,omitempty"`
+	StatusText    *string `json:"status_text,omitempty"`
+	AuthorsCount  *int    `json:"authors_count,omitempty"`
+	Percent       *int    `json:"percent,omitempty"`
+	PushPercent   *int    `json:"push_percent,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	HTMLURL       *string `json:"html_url,omitempty"`
+	AuthorsURL    *string `json:"authors_url,omitempty"`
+	RepositoryURL *string `json:"repository_url,omitempty"`
+	Message       *string `json:"message,omitempty"`
+	FailedStep    *string `json:"failed_step,omitempty"`
+
+	// Human readable display name, provided when the Import appears as
+	// part of ProjectChoices.
+	HumanName *string `json:"human_name,omitempty"`
+
+	// When the importer finds several projects or repositories at the
+	// provided URLs, this will identify the available choices.  Call
+	// UpdateImport with the selected Import value.
+	ProjectChoices []Import `json:"project_choices,omitempty"`
+}
+
+func (i Import) String() string {
+	return Stringify(i)
+}
+
+// SourceImportAuthor identifies an author imported from a source repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-commit-authors
+type SourceImportAuthor struct {
+	ID         *int    `json:"id,omitempty"`
+	RemoteID   *string `json:"remote_id,omitempty"`
+	RemoteName *string `json:"remote_name,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	URL        *string `json:"url,omitempty"`
+	ImportURL  *string `json:"import_url,omitempty"`
+}
+
+func (a SourceImportAuthor) String() string {
+	return Stringify(a)
+}
+
+// LargeFile identifies a file larger than 100MB found during a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-large-files
+type LargeFile struct {
+	RefName *string `json:"ref_name,omitempty"`
+	Path    *string `json:"path,omitempty"`
+	OID     *string `json:"oid,omitempty"`
+	Size    *int    `json:"size,omitempty"`
+}
+
+func (f LargeFile) String() string {
+	return Stringify(f)
+}
+
+// StartImport initiates a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#start-an-import
+func (s *MigrationService) StartImport(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("PUT", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// ImportProgress queries for the status and progress of an ongoing repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-import-progress
+func (s *MigrationService) ImportProgress(owner, repo string) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// UpdateImport initiates a repository import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#update-existing-import
+func (s *MigrationService) UpdateImport(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("PATCH", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// CommitAuthors gets the authors mapped from the original repository.
+//
+// Each type of source control system represents authors in a different way.
+// For example, a Git commit author has a display name and an email address,
+// but a Subversion commit author just has a username. The GitHub Importer will
+// make the author information valid, but the author might not be correct. For
+// example, it will change the bare Subversion username "hubot" into something
+// like "hubot <hubot@12341234-abab-fefe-8787-fedcba987654>".
+//
+// This method and MapCommitAuthor allow you to provide correct Git author
+// information.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-commit-authors
+func (s *MigrationService) CommitAuthors(owner, repo string) ([]*SourceImportAuthor, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/authors", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	authors := new([]*SourceImportAuthor)
+	resp, err := s.client.Do(req, authors)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *authors, resp, err
+}
+
+// MapCommitAuthor updates an author's identity for the import. Your
+// application can continue updating authors any time before you push new
+// commits to the repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#map-a-commit-author
+func (s *MigrationService) MapCommitAuthor(owner, repo string, id int, author *SourceImportAuthor) (*SourceImportAuthor, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/authors/%v", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, author)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(SourceImportAuthor)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// SetLFSPreference sets whether imported repositories should use Git LFS for
+// files larger than 100MB.  Only the UseLFS field on the provided Import is
+// used.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#set-git-lfs-preference
+func (s *MigrationService) SetLFSPreference(owner, repo string, in *Import) (*Import, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/lfs", owner, repo)
+	req, err := s.client.NewRequest("PATCH", u, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	out := new(Import)
+	resp, err := s.client.Do(req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, err
+}
+
+// LargeFiles lists files larger than 100MB found during the import.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#get-large-files
+func (s *MigrationService) LargeFiles(owner, repo string) ([]*LargeFile, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import/large_files", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	files := new([]*LargeFile)
+	resp, err := s.client.Do(req, files)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *files, resp, err
+}
+
+// CancelImport stops an import for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/migration/source_imports/#cancel-an-import
+func (s *MigrationService) CancelImport(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/import", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches
+	req.Header.Set("Accept", mediaTypeImportPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/misc.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/misc.go
@@ -1,0 +1,197 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+)
+
+// MarkdownOptions specifies optional parameters to the Markdown method.
+type MarkdownOptions struct {
+	// Mode identifies the rendering mode.  Possible values are:
+	//   markdown - render a document as plain Markdown, just like
+	//   README files are rendered.
+	//
+	//   gfm - to render a document as user-content, e.g. like user
+	//   comments or issues are rendered. In GFM mode, hard line breaks are
+	//   always taken into account, and issue and user mentions are linked
+	//   accordingly.
+	//
+	// Default is "markdown".
+	Mode string
+
+	// Context identifies the repository context.  Only taken into account
+	// when rendering as "gfm".
+	Context string
+}
+
+type markdownRequest struct {
+	Text    *string `json:"text,omitempty"`
+	Mode    *string `json:"mode,omitempty"`
+	Context *string `json:"context,omitempty"`
+}
+
+// Markdown renders an arbitrary Markdown document.
+//
+// GitHub API docs: https://developer.github.com/v3/markdown/
+func (c *Client) Markdown(text string, opt *MarkdownOptions) (string, *Response, error) {
+	request := &markdownRequest{Text: String(text)}
+	if opt != nil {
+		if opt.Mode != "" {
+			request.Mode = String(opt.Mode)
+		}
+		if opt.Context != "" {
+			request.Context = String(opt.Context)
+		}
+	}
+
+	req, err := c.NewRequest("POST", "markdown", request)
+	if err != nil {
+		return "", nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	resp, err := c.Do(req, buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, nil
+}
+
+// ListEmojis returns the emojis available to use on GitHub.
+//
+// GitHub API docs: https://developer.github.com/v3/emojis/
+func (c *Client) ListEmojis() (map[string]string, *Response, error) {
+	req, err := c.NewRequest("GET", "emojis", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var emoji map[string]string
+	resp, err := c.Do(req, &emoji)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return emoji, resp, nil
+}
+
+// APIMeta represents metadata about the GitHub API.
+type APIMeta struct {
+	// An Array of IP addresses in CIDR format specifying the addresses
+	// that incoming service hooks will originate from on GitHub.com.
+	Hooks []string `json:"hooks,omitempty"`
+
+	// An Array of IP addresses in CIDR format specifying the Git servers
+	// for GitHub.com.
+	Git []string `json:"git,omitempty"`
+
+	// Whether authentication with username and password is supported.
+	// (GitHub Enterprise instances using CAS or OAuth for authentication
+	// will return false. Features like Basic Authentication with a
+	// username and password, sudo mode, and two-factor authentication are
+	// not supported on these servers.)
+	VerifiablePasswordAuthentication *bool `json:"verifiable_password_authentication,omitempty"`
+
+	// An array of IP addresses in CIDR format specifying the addresses
+	// which serve GitHub Pages websites.
+	Pages []string `json:"pages,omitempty"`
+}
+
+// APIMeta returns information about GitHub.com, the service. Or, if you access
+// this endpoint on your organization’s GitHub Enterprise installation, this
+// endpoint provides information about that installation.
+//
+// GitHub API docs: https://developer.github.com/v3/meta/
+func (c *Client) APIMeta() (*APIMeta, *Response, error) {
+	req, err := c.NewRequest("GET", "meta", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta := new(APIMeta)
+	resp, err := c.Do(req, meta)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return meta, resp, nil
+}
+
+// Octocat returns an ASCII art octocat with the specified message in a speech
+// bubble.  If message is empty, a random zen phrase is used.
+func (c *Client) Octocat(message string) (string, *Response, error) {
+	u := "octocat"
+	if message != "" {
+		u = fmt.Sprintf("%s?s=%s", u, url.QueryEscape(message))
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	resp, err := c.Do(req, buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, nil
+}
+
+// Zen returns a random line from The Zen of GitHub.
+//
+// see also: http://warpspire.com/posts/taste/
+func (c *Client) Zen() (string, *Response, error) {
+	req, err := c.NewRequest("GET", "zen", nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	resp, err := c.Do(req, buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, nil
+}
+
+// ServiceHook represents a hook that has configuration settings, a list of
+// available events, and default events.
+type ServiceHook struct {
+	Name            *string    `json:"name,omitempty"`
+	Events          []string   `json:"events,omitempty"`
+	SupportedEvents []string   `json:"supported_events,omitempty"`
+	Schema          [][]string `json:"schema,omitempty"`
+}
+
+func (s *ServiceHook) String() string {
+	return Stringify(s)
+}
+
+// ListServiceHooks lists all of the available service hooks.
+//
+// GitHub API docs: https://developer.github.com/webhooks/#services
+func (c *Client) ListServiceHooks() ([]*ServiceHook, *Response, error) {
+	u := "hooks"
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hooks := new([]*ServiceHook)
+	resp, err := c.Do(req, hooks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *hooks, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs.go
@@ -1,0 +1,173 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// OrganizationsService provides access to the organization related functions
+// in the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/
+type OrganizationsService service
+
+// Organization represents a GitHub organization account.
+type Organization struct {
+	Login             *string    `json:"login,omitempty"`
+	ID                *int       `json:"id,omitempty"`
+	AvatarURL         *string    `json:"avatar_url,omitempty"`
+	HTMLURL           *string    `json:"html_url,omitempty"`
+	Name              *string    `json:"name,omitempty"`
+	Company           *string    `json:"company,omitempty"`
+	Blog              *string    `json:"blog,omitempty"`
+	Location          *string    `json:"location,omitempty"`
+	Email             *string    `json:"email,omitempty"`
+	Description       *string    `json:"description,omitempty"`
+	PublicRepos       *int       `json:"public_repos,omitempty"`
+	PublicGists       *int       `json:"public_gists,omitempty"`
+	Followers         *int       `json:"followers,omitempty"`
+	Following         *int       `json:"following,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+	TotalPrivateRepos *int       `json:"total_private_repos,omitempty"`
+	OwnedPrivateRepos *int       `json:"owned_private_repos,omitempty"`
+	PrivateGists      *int       `json:"private_gists,omitempty"`
+	DiskUsage         *int       `json:"disk_usage,omitempty"`
+	Collaborators     *int       `json:"collaborators,omitempty"`
+	BillingEmail      *string    `json:"billing_email,omitempty"`
+	Type              *string    `json:"type,omitempty"`
+	Plan              *Plan      `json:"plan,omitempty"`
+
+	// API URLs
+	URL              *string `json:"url,omitempty"`
+	EventsURL        *string `json:"events_url,omitempty"`
+	HooksURL         *string `json:"hooks_url,omitempty"`
+	IssuesURL        *string `json:"issues_url,omitempty"`
+	MembersURL       *string `json:"members_url,omitempty"`
+	PublicMembersURL *string `json:"public_members_url,omitempty"`
+	ReposURL         *string `json:"repos_url,omitempty"`
+}
+
+func (o Organization) String() string {
+	return Stringify(o)
+}
+
+// Plan represents the payment plan for an account.  See plans at https://github.com/plans.
+type Plan struct {
+	Name          *string `json:"name,omitempty"`
+	Space         *int    `json:"space,omitempty"`
+	Collaborators *int    `json:"collaborators,omitempty"`
+	PrivateRepos  *int    `json:"private_repos,omitempty"`
+}
+
+func (p Plan) String() string {
+	return Stringify(p)
+}
+
+// OrganizationsListOptions specifies the optional parameters to the
+// OrganizationsService.ListAll method.
+type OrganizationsListOptions struct {
+	// Since filters Organizations by ID.
+	Since int `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListAll lists all organizations, in the order that they were created on GitHub.
+//
+// Note: Pagination is powered exclusively by the since parameter. To continue
+// listing the next set of organizations, use the ID of the last-returned organization
+// as the opts.Since parameter for the next call.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/#list-all-organizations
+func (s *OrganizationsService) ListAll(opt *OrganizationsListOptions) ([]*Organization, *Response, error) {
+	u, err := addOptions("organizations", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	orgs := []*Organization{}
+	resp, err := s.client.Do(req, &orgs)
+	if err != nil {
+		return nil, resp, err
+	}
+	return orgs, resp, err
+}
+
+// List the organizations for a user.  Passing the empty string will list
+// organizations for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/#list-user-organizations
+func (s *OrganizationsService) List(user string, opt *ListOptions) ([]*Organization, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/orgs", user)
+	} else {
+		u = "user/orgs"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	orgs := new([]*Organization)
+	resp, err := s.client.Do(req, orgs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *orgs, resp, err
+}
+
+// Get fetches an organization by name.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/#get-an-organization
+func (s *OrganizationsService) Get(org string) (*Organization, *Response, error) {
+	u := fmt.Sprintf("orgs/%v", org)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	organization := new(Organization)
+	resp, err := s.client.Do(req, organization)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return organization, resp, err
+}
+
+// Edit an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/#edit-an-organization
+func (s *OrganizationsService) Edit(name string, org *Organization) (*Organization, *Response, error) {
+	u := fmt.Sprintf("orgs/%v", name)
+	req, err := s.client.NewRequest("PATCH", u, org)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := new(Organization)
+	resp, err := s.client.Do(req, o)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return o, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_hooks.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_hooks.go
@@ -1,0 +1,104 @@
+// Copyright 2015 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ListHooks lists all Hooks for the specified organization.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#list-hooks
+func (s *OrganizationsService) ListHooks(org string, opt *ListOptions) ([]*Hook, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks", org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hooks := new([]*Hook)
+	resp, err := s.client.Do(req, hooks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *hooks, resp, err
+}
+
+// GetHook returns a single specified Hook.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#get-single-hook
+func (s *OrganizationsService) GetHook(org string, id int) (*Hook, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	hook := new(Hook)
+	resp, err := s.client.Do(req, hook)
+	return hook, resp, err
+}
+
+// CreateHook creates a Hook for the specified org.
+// Name and Config are required fields.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#create-a-hook
+func (s *OrganizationsService) CreateHook(org string, hook *Hook) (*Hook, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks", org)
+	req, err := s.client.NewRequest("POST", u, hook)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	h := new(Hook)
+	resp, err := s.client.Do(req, h)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return h, resp, err
+}
+
+// EditHook updates a specified Hook.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#edit-a-hook
+func (s *OrganizationsService) EditHook(org string, id int, hook *Hook) (*Hook, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	req, err := s.client.NewRequest("PATCH", u, hook)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := new(Hook)
+	resp, err := s.client.Do(req, h)
+	return h, resp, err
+}
+
+// PingHook triggers a 'ping' event to be sent to the Hook.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#ping-a-hook
+func (s *OrganizationsService) PingHook(org string, id int) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d/pings", org, id)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// DeleteHook deletes a specified Hook.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/hooks/#delete-a-hook
+func (s *OrganizationsService) DeleteHook(org string, id int) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/hooks/%d", org, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_members.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_members.go
@@ -1,0 +1,272 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Membership represents the status of a user's membership in an organization or team.
+type Membership struct {
+	URL *string `json:"url,omitempty"`
+
+	// State is the user's status within the organization or team.
+	// Possible values are: "active", "pending"
+	State *string `json:"state,omitempty"`
+
+	// Role identifies the user's role within the organization or team.
+	// Possible values for organization membership:
+	//     member - non-owner organization member
+	//     admin - organization owner
+	//
+	// Possible values for team membership are:
+	//     member - a normal member of the team
+	//     maintainer - a team maintainer. Able to add/remove other team
+	//                  members, promote other team members to team
+	//                  maintainer, and edit the team’s name and description
+	Role *string `json:"role,omitempty"`
+
+	// For organization membership, the API URL of the organization.
+	OrganizationURL *string `json:"organization_url,omitempty"`
+
+	// For organization membership, the organization the membership is for.
+	Organization *Organization `json:"organization,omitempty"`
+
+	// For organization membership, the user the membership is for.
+	User *User `json:"user,omitempty"`
+}
+
+func (m Membership) String() string {
+	return Stringify(m)
+}
+
+// ListMembersOptions specifies optional parameters to the
+// OrganizationsService.ListMembers method.
+type ListMembersOptions struct {
+	// If true (or if the authenticated user is not an owner of the
+	// organization), list only publicly visible members.
+	PublicOnly bool `url:"-"`
+
+	// Filter members returned in the list.  Possible values are:
+	// 2fa_disabled, all.  Default is "all".
+	Filter string `url:"filter,omitempty"`
+
+	// Role filters members returned by their role in the organization.
+	// Possible values are:
+	//     all - all members of the organization, regardless of role
+	//     admin - organization owners
+	//     member - non-organization members
+	//
+	// Default is "all".
+	Role string `url:"role,omitempty"`
+
+	ListOptions
+}
+
+// ListMembers lists the members for an organization.  If the authenticated
+// user is an owner of the organization, this will return both concealed and
+// public members, otherwise it will only return public members.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#members-list
+func (s *OrganizationsService) ListMembers(org string, opt *ListMembersOptions) ([]*User, *Response, error) {
+	var u string
+	if opt != nil && opt.PublicOnly {
+		u = fmt.Sprintf("orgs/%v/public_members", org)
+	} else {
+		u = fmt.Sprintf("orgs/%v/members", org)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	members := new([]*User)
+	resp, err := s.client.Do(req, members)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *members, resp, err
+}
+
+// IsMember checks if a user is a member of an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#check-membership
+func (s *OrganizationsService) IsMember(org, user string) (bool, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	member, err := parseBoolResponse(err)
+	return member, resp, err
+}
+
+// IsPublicMember checks if a user is a public member of an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#check-public-membership
+func (s *OrganizationsService) IsPublicMember(org, user string) (bool, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	member, err := parseBoolResponse(err)
+	return member, resp, err
+}
+
+// RemoveMember removes a user from all teams of an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#remove-a-member
+func (s *OrganizationsService) RemoveMember(org, user string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/members/%v", org, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// PublicizeMembership publicizes a user's membership in an organization. (A
+// user cannot publicize the membership for another user.)
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#publicize-a-users-membership
+func (s *OrganizationsService) PublicizeMembership(org, user string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ConcealMembership conceals a user's membership in an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/members/#conceal-a-users-membership
+func (s *OrganizationsService) ConcealMembership(org, user string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/public_members/%v", org, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListOrgMembershipsOptions specifies optional parameters to the
+// OrganizationsService.ListOrgMemberships method.
+type ListOrgMembershipsOptions struct {
+	// Filter memberships to include only those with the specified state.
+	// Possible values are: "active", "pending".
+	State string `url:"state,omitempty"`
+
+	ListOptions
+}
+
+// ListOrgMemberships lists the organization memberships for the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#list-your-organization-memberships
+func (s *OrganizationsService) ListOrgMemberships(opt *ListOrgMembershipsOptions) ([]*Membership, *Response, error) {
+	u := "user/memberships/orgs"
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var memberships []*Membership
+	resp, err := s.client.Do(req, &memberships)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return memberships, resp, err
+}
+
+// GetOrgMembership gets the membership for a user in a specified organization.
+// Passing an empty string for user will get the membership for the
+// authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#get-organization-membership
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#get-your-organization-membership
+func (s *OrganizationsService) GetOrgMembership(user, org string) (*Membership, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("orgs/%v/memberships/%v", org, user)
+	} else {
+		u = fmt.Sprintf("user/memberships/orgs/%v", org)
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	membership := new(Membership)
+	resp, err := s.client.Do(req, membership)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return membership, resp, err
+}
+
+// EditOrgMembership edits the membership for user in specified organization.
+// Passing an empty string for user will edit the membership for the
+// authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#edit-your-organization-membership
+func (s *OrganizationsService) EditOrgMembership(user, org string, membership *Membership) (*Membership, *Response, error) {
+	var u, method string
+	if user != "" {
+		u = fmt.Sprintf("orgs/%v/memberships/%v", org, user)
+		method = "PUT"
+	} else {
+		u = fmt.Sprintf("user/memberships/orgs/%v", org)
+		method = "PATCH"
+	}
+
+	req, err := s.client.NewRequest(method, u, membership)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(Membership)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// RemoveOrgMembership removes user from the specified organization.  If the
+// user has been invited to the organization, this will cancel their invitation.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/members/#remove-organization-membership
+func (s *OrganizationsService) RemoveOrgMembership(user, org string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/memberships/%v", org, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_teams.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/orgs_teams.go
@@ -1,0 +1,379 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Team represents a team within a GitHub organization.  Teams are used to
+// manage access to an organization's repositories.
+type Team struct {
+	ID          *int    `json:"id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	URL         *string `json:"url,omitempty"`
+	Slug        *string `json:"slug,omitempty"`
+
+	// Permission is deprecated when creating or editing a team in an org
+	// using the new GitHub permission model.  It no longer identifies the
+	// permission a team has on its repos, but only specifies the default
+	// permission a repo is initially added with.  Avoid confusion by
+	// specifying a permission value when calling AddTeamRepo.
+	Permission *string `json:"permission,omitempty"`
+
+	// Privacy identifies the level of privacy this team should have.
+	// Possible values are:
+	//     secret - only visible to organization owners and members of this team
+	//     closed - visible to all members of this organization
+	// Default is "secret".
+	Privacy *string `json:"privacy,omitempty"`
+
+	MembersCount    *int          `json:"members_count,omitempty"`
+	ReposCount      *int          `json:"repos_count,omitempty"`
+	Organization    *Organization `json:"organization,omitempty"`
+	MembersURL      *string       `json:"members_url,omitempty"`
+	RepositoriesURL *string       `json:"repositories_url,omitempty"`
+}
+
+func (t Team) String() string {
+	return Stringify(t)
+}
+
+// ListTeams lists all of the teams for an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-teams
+func (s *OrganizationsService) ListTeams(org string, opt *ListOptions) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams", org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	teams := new([]*Team)
+	resp, err := s.client.Do(req, teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *teams, resp, err
+}
+
+// GetTeam fetches a team by ID.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#get-team
+func (s *OrganizationsService) GetTeam(team int) (*Team, *Response, error) {
+	u := fmt.Sprintf("teams/%v", team)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Team)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// CreateTeam creates a new team within an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#create-team
+func (s *OrganizationsService) CreateTeam(org string, team *Team) (*Team, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/teams", org)
+	req, err := s.client.NewRequest("POST", u, team)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Team)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// EditTeam edits a team.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#edit-team
+func (s *OrganizationsService) EditTeam(id int, team *Team) (*Team, *Response, error) {
+	u := fmt.Sprintf("teams/%v", id)
+	req, err := s.client.NewRequest("PATCH", u, team)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Team)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// DeleteTeam deletes a team.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#delete-team
+func (s *OrganizationsService) DeleteTeam(team int) (*Response, error) {
+	u := fmt.Sprintf("teams/%v", team)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// OrganizationListTeamMembersOptions specifies the optional parameters to the
+// OrganizationsService.ListTeamMembers method.
+type OrganizationListTeamMembersOptions struct {
+	// Role filters members returned by their role in the team.  Possible
+	// values are "all", "member", "maintainer".  Default is "all".
+	Role string `url:"role,omitempty"`
+
+	ListOptions
+}
+
+// ListTeamMembers lists all of the users who are members of the specified
+// team.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-team-members
+func (s *OrganizationsService) ListTeamMembers(team int, opt *OrganizationListTeamMembersOptions) ([]*User, *Response, error) {
+	u := fmt.Sprintf("teams/%v/members", team)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	members := new([]*User)
+	resp, err := s.client.Do(req, members)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *members, resp, err
+}
+
+// IsTeamMember checks if a user is a member of the specified team.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#get-team-member
+func (s *OrganizationsService) IsTeamMember(team int, user string) (bool, *Response, error) {
+	u := fmt.Sprintf("teams/%v/members/%v", team, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	member, err := parseBoolResponse(err)
+	return member, resp, err
+}
+
+// ListTeamRepos lists the repositories that the specified team has access to.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#list-team-repos
+func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]*Repository, *Response, error) {
+	u := fmt.Sprintf("teams/%v/repos", team)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repos := new([]*Repository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// IsTeamRepo checks if a team manages the specified repository.  If the
+// repository is managed by team, a Repository is returned which includes the
+// permissions team has for that repo.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#check-if-a-team-manages-a-repository
+func (s *OrganizationsService) IsTeamRepo(team int, owner string, repo string) (*Repository, *Response, error) {
+	u := fmt.Sprintf("teams/%v/repos/%v/%v", team, owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
+
+	repository := new(Repository)
+	resp, err := s.client.Do(req, repository)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repository, resp, err
+}
+
+// OrganizationAddTeamRepoOptions specifies the optional parameters to the
+// OrganizationsService.AddTeamRepo method.
+type OrganizationAddTeamRepoOptions struct {
+	// Permission specifies the permission to grant the team on this repository.
+	// Possible values are:
+	//     pull - team members can pull, but not push to or administer this repository
+	//     push - team members can pull and push, but not administer this repository
+	//     admin - team members can pull, push and administer this repository
+	//
+	// If not specified, the team's permission attribute will be used.
+	Permission string `json:"permission,omitempty"`
+}
+
+// AddTeamRepo adds a repository to be managed by the specified team.  The
+// specified repository must be owned by the organization to which the team
+// belongs, or a direct fork of a repository owned by the organization.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#add-team-repo
+func (s *OrganizationsService) AddTeamRepo(team int, owner string, repo string, opt *OrganizationAddTeamRepoOptions) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/repos/%v/%v", team, owner, repo)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveTeamRepo removes a repository from being managed by the specified
+// team.  Note that this does not delete the repository, it just removes it
+// from the team.
+//
+// GitHub API docs: http://developer.github.com/v3/orgs/teams/#remove-team-repo
+func (s *OrganizationsService) RemoveTeamRepo(team int, owner string, repo string) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/repos/%v/%v", team, owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListUserTeams lists a user's teams
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#list-user-teams
+func (s *OrganizationsService) ListUserTeams(opt *ListOptions) ([]*Team, *Response, error) {
+	u := "user/teams"
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	teams := new([]*Team)
+	resp, err := s.client.Do(req, teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *teams, resp, err
+}
+
+// GetTeamMembership returns the membership status for a user in a team.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#get-team-membership
+func (s *OrganizationsService) GetTeamMembership(team int, user string) (*Membership, *Response, error) {
+	u := fmt.Sprintf("teams/%v/memberships/%v", team, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Membership)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// OrganizationAddTeamMembershipOptions does stuff specifies the optional
+// parameters to the OrganizationsService.AddTeamMembership method.
+type OrganizationAddTeamMembershipOptions struct {
+	// Role specifies the role the user should have in the team.  Possible
+	// values are:
+	//     member - a normal member of the team
+	//     maintainer - a team maintainer. Able to add/remove other team
+	//                  members, promote other team members to team
+	//                  maintainer, and edit the team’s name and description
+	//
+	// Default value is "member".
+	Role string `json:"role,omitempty"`
+}
+
+// AddTeamMembership adds or invites a user to a team.
+//
+// In order to add a membership between a user and a team, the authenticated
+// user must have 'admin' permissions to the team or be an owner of the
+// organization that the team is associated with.
+//
+// If the user is already a part of the team's organization (meaning they're on
+// at least one other team in the organization), this endpoint will add the
+// user to the team.
+//
+// If the user is completely unaffiliated with the team's organization (meaning
+// they're on none of the organization's teams), this endpoint will send an
+// invitation to the user via email. This newly-created membership will be in
+// the "pending" state until the user accepts the invitation, at which point
+// the membership will transition to the "active" state and the user will be
+// added as a member of the team.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#add-team-membership
+func (s *OrganizationsService) AddTeamMembership(team int, user string, opt *OrganizationAddTeamMembershipOptions) (*Membership, *Response, error) {
+	u := fmt.Sprintf("teams/%v/memberships/%v", team, user)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(Membership)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// RemoveTeamMembership removes a user from a team.
+//
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#remove-team-membership
+func (s *OrganizationsService) RemoveTeamMembership(team int, user string) (*Response, error) {
+	u := fmt.Sprintf("teams/%v/memberships/%v", team, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/pulls.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/pulls.go
@@ -1,0 +1,287 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// PullRequestsService handles communication with the pull request related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/pulls/
+type PullRequestsService service
+
+// PullRequest represents a GitHub pull request on a repository.
+type PullRequest struct {
+	ID           *int       `json:"id,omitempty"`
+	Number       *int       `json:"number,omitempty"`
+	State        *string    `json:"state,omitempty"`
+	Title        *string    `json:"title,omitempty"`
+	Body         *string    `json:"body,omitempty"`
+	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	ClosedAt     *time.Time `json:"closed_at,omitempty"`
+	MergedAt     *time.Time `json:"merged_at,omitempty"`
+	User         *User      `json:"user,omitempty"`
+	Merged       *bool      `json:"merged,omitempty"`
+	Mergeable    *bool      `json:"mergeable,omitempty"`
+	MergedBy     *User      `json:"merged_by,omitempty"`
+	Comments     *int       `json:"comments,omitempty"`
+	Commits      *int       `json:"commits,omitempty"`
+	Additions    *int       `json:"additions,omitempty"`
+	Deletions    *int       `json:"deletions,omitempty"`
+	ChangedFiles *int       `json:"changed_files,omitempty"`
+	URL          *string    `json:"url,omitempty"`
+	HTMLURL      *string    `json:"html_url,omitempty"`
+	IssueURL     *string    `json:"issue_url,omitempty"`
+	StatusesURL  *string    `json:"statuses_url,omitempty"`
+	DiffURL      *string    `json:"diff_url,omitempty"`
+	PatchURL     *string    `json:"patch_url,omitempty"`
+	Assignee     *User      `json:"assignee,omitempty"`
+	Assignees    []*User    `json:"assignees,omitempty"`
+	Milestone    *Milestone `json:"milestone,omitempty"`
+
+	Head *PullRequestBranch `json:"head,omitempty"`
+	Base *PullRequestBranch `json:"base,omitempty"`
+}
+
+func (p PullRequest) String() string {
+	return Stringify(p)
+}
+
+// PullRequestBranch represents a base or head branch in a GitHub pull request.
+type PullRequestBranch struct {
+	Label *string     `json:"label,omitempty"`
+	Ref   *string     `json:"ref,omitempty"`
+	SHA   *string     `json:"sha,omitempty"`
+	Repo  *Repository `json:"repo,omitempty"`
+	User  *User       `json:"user,omitempty"`
+}
+
+// PullRequestListOptions specifies the optional parameters to the
+// PullRequestsService.List method.
+type PullRequestListOptions struct {
+	// State filters pull requests based on their state.  Possible values are:
+	// open, closed.  Default is "open".
+	State string `url:"state,omitempty"`
+
+	// Head filters pull requests by head user and branch name in the format of:
+	// "user:ref-name".
+	Head string `url:"head,omitempty"`
+
+	// Base filters pull requests by base branch name.
+	Base string `url:"base,omitempty"`
+
+	// Sort specifies how to sort pull requests. Possible values are: created,
+	// updated, popularity, long-running. Default is "created".
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort pull requests. Possible values are: asc, desc.
+	// If Sort is "created" or not specified, Default is "desc", otherwise Default
+	// is "asc"
+	Direction string `url:"direction,omitempty"`
+
+	ListOptions
+}
+
+// List the pull requests for the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/pulls/#list-pull-requests
+func (s *PullRequestsService) List(owner string, repo string, opt *PullRequestListOptions) ([]*PullRequest, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pulls := new([]*PullRequest)
+	resp, err := s.client.Do(req, pulls)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *pulls, resp, err
+}
+
+// Get a single pull request.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#get-a-single-pull-request
+func (s *PullRequestsService) Get(owner string, repo string, number int) (*PullRequest, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pull := new(PullRequest)
+	resp, err := s.client.Do(req, pull)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pull, resp, err
+}
+
+// NewPullRequest represents a new pull request to be created.
+type NewPullRequest struct {
+	Title *string `json:"title,omitempty"`
+	Head  *string `json:"head,omitempty"`
+	Base  *string `json:"base,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	Issue *int    `json:"issue,omitempty"`
+}
+
+// Create a new pull request on the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#create-a-pull-request
+func (s *PullRequestsService) Create(owner string, repo string, pull *NewPullRequest) (*PullRequest, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
+	req, err := s.client.NewRequest("POST", u, pull)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PullRequest)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// Edit a pull request.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#update-a-pull-request
+func (s *PullRequestsService) Edit(owner string, repo string, number int, pull *PullRequest) (*PullRequest, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
+	req, err := s.client.NewRequest("PATCH", u, pull)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PullRequest)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// ListCommits lists the commits in a pull request.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
+func (s *PullRequestsService) ListCommits(owner string, repo string, number int, opt *ListOptions) ([]*RepositoryCommit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/commits", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	commits := new([]*RepositoryCommit)
+	resp, err := s.client.Do(req, commits)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *commits, resp, err
+}
+
+// ListFiles lists the files in a pull request.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#list-pull-requests-files
+func (s *PullRequestsService) ListFiles(owner string, repo string, number int, opt *ListOptions) ([]*CommitFile, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/files", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	commitFiles := new([]*CommitFile)
+	resp, err := s.client.Do(req, commitFiles)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *commitFiles, resp, err
+}
+
+// IsMerged checks if a pull request has been merged.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
+func (s *PullRequestsService) IsMerged(owner string, repo string, number int) (bool, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	merged, err := parseBoolResponse(err)
+	return merged, resp, err
+}
+
+// PullRequestMergeResult represents the result of merging a pull request.
+type PullRequestMergeResult struct {
+	SHA     *string `json:"sha,omitempty"`
+	Merged  *bool   `json:"merged,omitempty"`
+	Message *string `json:"message,omitempty"`
+}
+
+// PullRequestOptions lets you define how a pull request will be merged.
+type PullRequestOptions struct {
+	Squash bool
+}
+
+type pullRequestMergeRequest struct {
+	CommitMessage *string `json:"commit_message"`
+	Squash        *bool   `json:"squash,omitempty"`
+}
+
+// Merge a pull request (Merge Button™).
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade
+func (s *PullRequestsService) Merge(owner string, repo string, number int, commitMessage string, options *PullRequestOptions) (*PullRequestMergeResult, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/merge", owner, repo, number)
+
+	pullRequestBody := &pullRequestMergeRequest{CommitMessage: &commitMessage}
+	if options != nil {
+		pullRequestBody.Squash = &options.Squash
+	}
+	req, err := s.client.NewRequest("PUT", u, pullRequestBody)
+
+	// TODO: This header will be unnecessary when the API is no longer in preview.
+	req.Header.Set("Accept", mediaTypeSquashPreview)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mergeResult := new(PullRequestMergeResult)
+	resp, err := s.client.Do(req, mergeResult)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mergeResult, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/pulls_comments.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/pulls_comments.go
@@ -1,0 +1,156 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// PullRequestComment represents a comment left on a pull request.
+type PullRequestComment struct {
+	ID               *int       `json:"id,omitempty"`
+	InReplyTo        *int       `json:"in_reply_to,omitempty"`
+	Body             *string    `json:"body,omitempty"`
+	Path             *string    `json:"path,omitempty"`
+	DiffHunk         *string    `json:"diff_hunk,omitempty"`
+	Position         *int       `json:"position,omitempty"`
+	OriginalPosition *int       `json:"original_position,omitempty"`
+	CommitID         *string    `json:"commit_id,omitempty"`
+	OriginalCommitID *string    `json:"original_commit_id,omitempty"`
+	User             *User      `json:"user,omitempty"`
+	Reactions        *Reactions `json:"reactions,omitempty"`
+	CreatedAt        *time.Time `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	URL              *string    `json:"url,omitempty"`
+	HTMLURL          *string    `json:"html_url,omitempty"`
+	PullRequestURL   *string    `json:"pull_request_url,omitempty"`
+}
+
+func (p PullRequestComment) String() string {
+	return Stringify(p)
+}
+
+// PullRequestListCommentsOptions specifies the optional parameters to the
+// PullRequestsService.ListComments method.
+type PullRequestListCommentsOptions struct {
+	// Sort specifies how to sort comments.  Possible values are: created, updated.
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort comments.  Possible values are: asc, desc.
+	Direction string `url:"direction,omitempty"`
+
+	// Since filters comments by time.
+	Since time.Time `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListComments lists all comments on the specified pull request.  Specifying a
+// pull request number of 0 will return all comments on all pull requests for
+// the repository.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
+func (s *PullRequestsService) ListComments(owner string, repo string, number int, opt *PullRequestListCommentsOptions) ([]*PullRequestComment, *Response, error) {
+	var u string
+	if number == 0 {
+		u = fmt.Sprintf("repos/%v/%v/pulls/comments", owner, repo)
+	} else {
+		u = fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comments := new([]*PullRequestComment)
+	resp, err := s.client.Do(req, comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *comments, resp, err
+}
+
+// GetComment fetches the specified pull request comment.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#get-a-single-comment
+func (s *PullRequestsService) GetComment(owner string, repo string, number int) (*PullRequestComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comment := new(PullRequestComment)
+	resp, err := s.client.Do(req, comment)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return comment, resp, err
+}
+
+// CreateComment creates a new comment on the specified pull request.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#create-a-comment
+func (s *PullRequestsService) CreateComment(owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%d/comments", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(PullRequestComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// EditComment updates a pull request comment.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#edit-a-comment
+func (s *PullRequestsService) EditComment(owner string, repo string, number int, comment *PullRequestComment) (*PullRequestComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(PullRequestComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// DeleteComment deletes a pull request comment.
+//
+// GitHub API docs: https://developer.github.com/v3/pulls/comments/#delete-a-comment
+func (s *PullRequestsService) DeleteComment(owner string, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%d", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/reactions.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/reactions.go
@@ -1,0 +1,270 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ReactionsService provides access to the reactions-related functions in the
+// GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/
+type ReactionsService service
+
+// Reaction represents a GitHub reaction.
+type Reaction struct {
+	// ID is the Reaction ID.
+	ID   *int  `json:"id,omitempty"`
+	User *User `json:"user,omitempty"`
+	// Content is the type of reaction.
+	// Possible values are:
+	//     "+1", "-1", "laugh", "confused", "heart", "hooray".
+	Content *string `json:"content,omitempty"`
+}
+
+// Reactions represents a summary of GitHub reactions.
+type Reactions struct {
+	TotalCount *int    `json:"total_count,omitempty"`
+	PlusOne    *int    `json:"+1,omitempty"`
+	MinusOne   *int    `json:"-1,omitempty"`
+	Laugh      *int    `json:"laugh,omitempty"`
+	Confused   *int    `json:"confused,omitempty"`
+	Heart      *int    `json:"heart,omitempty"`
+	Hooray     *int    `json:"hooray,omitempty"`
+	URL        *string `json:"url,omitempty"`
+}
+
+func (r Reaction) String() string {
+	return Stringify(r)
+}
+
+// ListCommentReactions lists the reactions for a commit comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
+func (s *ReactionsService) ListCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateCommentReaction creates a reaction for a commit comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
+func (s ReactionsService) CreateCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueReactions lists the reactions for an issue.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
+func (s *ReactionsService) ListIssueReactions(owner, repo string, number int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueReaction creates a reaction for an issue.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
+func (s ReactionsService) CreateIssueReaction(owner, repo string, number int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueCommentReactions lists the reactions for an issue comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListIssueCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueCommentReaction creates a reaction for an issue comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreateIssueCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListPullRequestCommentReactions lists the reactions for a pull request review comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListPullRequestCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreatePullRequestCommentReaction creates a reaction for a pull request review comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreatePullRequestCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// DeleteReaction deletes a reaction.
+//
+// GitHub API docs: https://developer.github.com/v3/reaction/reactions/#delete-a-reaction-archive
+func (s *ReactionsService) DeleteReaction(id int) (*Response, error) {
+	u := fmt.Sprintf("reactions/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos.go
@@ -1,0 +1,599 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// RepositoriesService handles communication with the repository related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/
+type RepositoriesService service
+
+// Repository represents a GitHub repository.
+type Repository struct {
+	ID               *int             `json:"id,omitempty"`
+	Owner            *User            `json:"owner,omitempty"`
+	Name             *string          `json:"name,omitempty"`
+	FullName         *string          `json:"full_name,omitempty"`
+	Description      *string          `json:"description,omitempty"`
+	Homepage         *string          `json:"homepage,omitempty"`
+	DefaultBranch    *string          `json:"default_branch,omitempty"`
+	MasterBranch     *string          `json:"master_branch,omitempty"`
+	CreatedAt        *Timestamp       `json:"created_at,omitempty"`
+	PushedAt         *Timestamp       `json:"pushed_at,omitempty"`
+	UpdatedAt        *Timestamp       `json:"updated_at,omitempty"`
+	HTMLURL          *string          `json:"html_url,omitempty"`
+	CloneURL         *string          `json:"clone_url,omitempty"`
+	GitURL           *string          `json:"git_url,omitempty"`
+	MirrorURL        *string          `json:"mirror_url,omitempty"`
+	SSHURL           *string          `json:"ssh_url,omitempty"`
+	SVNURL           *string          `json:"svn_url,omitempty"`
+	Language         *string          `json:"language,omitempty"`
+	Fork             *bool            `json:"fork"`
+	ForksCount       *int             `json:"forks_count,omitempty"`
+	NetworkCount     *int             `json:"network_count,omitempty"`
+	OpenIssuesCount  *int             `json:"open_issues_count,omitempty"`
+	StargazersCount  *int             `json:"stargazers_count,omitempty"`
+	SubscribersCount *int             `json:"subscribers_count,omitempty"`
+	WatchersCount    *int             `json:"watchers_count,omitempty"`
+	Size             *int             `json:"size,omitempty"`
+	AutoInit         *bool            `json:"auto_init,omitempty"`
+	Parent           *Repository      `json:"parent,omitempty"`
+	Source           *Repository      `json:"source,omitempty"`
+	Organization     *Organization    `json:"organization,omitempty"`
+	Permissions      *map[string]bool `json:"permissions,omitempty"`
+
+	// Only provided when using RepositoriesService.Get while in preview
+	License *License `json:"license,omitempty"`
+
+	// Additional mutable fields when creating and editing a repository
+	Private      *bool `json:"private"`
+	HasIssues    *bool `json:"has_issues"`
+	HasWiki      *bool `json:"has_wiki"`
+	HasPages     *bool `json:"has_pages"`
+	HasDownloads *bool `json:"has_downloads"`
+	// Creating an organization repository. Required for non-owners.
+	TeamID *int `json:"team_id"`
+
+	// API URLs
+	URL              *string `json:"url,omitempty"`
+	ArchiveURL       *string `json:"archive_url,omitempty"`
+	AssigneesURL     *string `json:"assignees_url,omitempty"`
+	BlobsURL         *string `json:"blobs_url,omitempty"`
+	BranchesURL      *string `json:"branches_url,omitempty"`
+	CollaboratorsURL *string `json:"collaborators_url,omitempty"`
+	CommentsURL      *string `json:"comments_url,omitempty"`
+	CommitsURL       *string `json:"commits_url,omitempty"`
+	CompareURL       *string `json:"compare_url,omitempty"`
+	ContentsURL      *string `json:"contents_url,omitempty"`
+	ContributorsURL  *string `json:"contributors_url,omitempty"`
+	DeploymentsURL   *string `json:"deployments_url,omitempty"`
+	DownloadsURL     *string `json:"downloads_url,omitempty"`
+	EventsURL        *string `json:"events_url,omitempty"`
+	ForksURL         *string `json:"forks_url,omitempty"`
+	GitCommitsURL    *string `json:"git_commits_url,omitempty"`
+	GitRefsURL       *string `json:"git_refs_url,omitempty"`
+	GitTagsURL       *string `json:"git_tags_url,omitempty"`
+	HooksURL         *string `json:"hooks_url,omitempty"`
+	IssueCommentURL  *string `json:"issue_comment_url,omitempty"`
+	IssueEventsURL   *string `json:"issue_events_url,omitempty"`
+	IssuesURL        *string `json:"issues_url,omitempty"`
+	KeysURL          *string `json:"keys_url,omitempty"`
+	LabelsURL        *string `json:"labels_url,omitempty"`
+	LanguagesURL     *string `json:"languages_url,omitempty"`
+	MergesURL        *string `json:"merges_url,omitempty"`
+	MilestonesURL    *string `json:"milestones_url,omitempty"`
+	NotificationsURL *string `json:"notifications_url,omitempty"`
+	PullsURL         *string `json:"pulls_url,omitempty"`
+	ReleasesURL      *string `json:"releases_url,omitempty"`
+	StargazersURL    *string `json:"stargazers_url,omitempty"`
+	StatusesURL      *string `json:"statuses_url,omitempty"`
+	SubscribersURL   *string `json:"subscribers_url,omitempty"`
+	SubscriptionURL  *string `json:"subscription_url,omitempty"`
+	TagsURL          *string `json:"tags_url,omitempty"`
+	TreesURL         *string `json:"trees_url,omitempty"`
+	TeamsURL         *string `json:"teams_url,omitempty"`
+
+	// TextMatches is only populated from search results that request text matches
+	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
+	TextMatches []TextMatch `json:"text_matches,omitempty"`
+}
+
+func (r Repository) String() string {
+	return Stringify(r)
+}
+
+// RepositoryListOptions specifies the optional parameters to the
+// RepositoriesService.List method.
+type RepositoryListOptions struct {
+	// Visibility of repositories to list. Can be one of all, public, or private.
+	// Default: all
+	Visibility string `url:"visibility,omitempty"`
+
+	// List repos of given affiliation[s].
+	// Comma-separated list of values. Can include:
+	// * owner: Repositories that are owned by the authenticated user.
+	// * collaborator: Repositories that the user has been added to as a
+	//   collaborator.
+	// * organization_member: Repositories that the user has access to through
+	//   being a member of an organization. This includes every repository on
+	//   every team that the user is on.
+	// Default: owner,collaborator,organization_member
+	Affiliation string `url:"affiliation,omitempty"`
+
+	// Type of repositories to list.
+	// Can be one of all, owner, public, private, member. Default: all
+	// Will cause a 422 error if used in the same request as visibility or
+	// affiliation.
+	Type string `url:"type,omitempty"`
+
+	// How to sort the repository list. Can be one of created, updated, pushed,
+	// full_name. Default: full_name
+	Sort string `url:"sort,omitempty"`
+
+	// Direction in which to sort repositories. Can be one of asc or desc.
+	// Default: when using full_name: asc; otherwise desc
+	Direction string `url:"direction,omitempty"`
+
+	ListOptions
+}
+
+// List the repositories for a user.  Passing the empty string will list
+// repositories for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#list-user-repositories
+func (s *RepositoriesService) List(user string, opt *RepositoryListOptions) ([]*Repository, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/repos", user)
+	} else {
+		u = "user/repos"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when license support fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	repos := new([]*Repository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// RepositoryListByOrgOptions specifies the optional parameters to the
+// RepositoriesService.ListByOrg method.
+type RepositoryListByOrgOptions struct {
+	// Type of repositories to list.  Possible values are: all, public, private,
+	// forks, sources, member.  Default is "all".
+	Type string `url:"type,omitempty"`
+
+	ListOptions
+}
+
+// ListByOrg lists the repositories for an organization.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#list-organization-repositories
+func (s *RepositoriesService) ListByOrg(org string, opt *RepositoryListByOrgOptions) ([]*Repository, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/repos", org)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when license support fully launches
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	repos := new([]*Repository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// RepositoryListAllOptions specifies the optional parameters to the
+// RepositoriesService.ListAll method.
+type RepositoryListAllOptions struct {
+	// ID of the last repository seen
+	Since int `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListAll lists all GitHub repositories in the order that they were created.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#list-all-public-repositories
+func (s *RepositoriesService) ListAll(opt *RepositoryListAllOptions) ([]*Repository, *Response, error) {
+	u, err := addOptions("repositories", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repos := new([]*Repository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// Create a new repository.  If an organization is specified, the new
+// repository will be created under that org.  If the empty string is
+// specified, it will be created for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#create
+func (s *RepositoriesService) Create(org string, repo *Repository) (*Repository, *Response, error) {
+	var u string
+	if org != "" {
+		u = fmt.Sprintf("orgs/%v/repos", org)
+	} else {
+		u = "user/repos"
+	}
+
+	req, err := s.client.NewRequest("POST", u, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Repository)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// Get fetches a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#get
+func (s *RepositoriesService) Get(owner, repo string) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when the license support fully launches
+	// https://developer.github.com/v3/licenses/#get-a-repositorys-license
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	repository := new(Repository)
+	resp, err := s.client.Do(req, repository)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repository, resp, err
+}
+
+// GetByID fetches a repository.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /repositories/:id.
+func (s *RepositoriesService) GetByID(id int) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repositories/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when the license support fully launches
+	// https://developer.github.com/v3/licenses/#get-a-repositorys-license
+	req.Header.Set("Accept", mediaTypeLicensesPreview)
+
+	repository := new(Repository)
+	resp, err := s.client.Do(req, repository)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repository, resp, err
+}
+
+// Edit updates a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#edit
+func (s *RepositoriesService) Edit(owner, repo string, repository *Repository) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("PATCH", u, repository)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(Repository)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
+// Delete a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#delete-a-repository
+func (s *RepositoriesService) Delete(owner, repo string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v", owner, repo)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Contributor represents a repository contributor
+type Contributor struct {
+	Login             *string `json:"login,omitempty"`
+	ID                *int    `json:"id,omitempty"`
+	AvatarURL         *string `json:"avatar_url,omitempty"`
+	GravatarID        *string `json:"gravatar_id,omitempty"`
+	URL               *string `json:"url,omitempty"`
+	HTMLURL           *string `json:"html_url,omitempty"`
+	FollowersURL      *string `json:"followers_url,omitempty"`
+	FollowingURL      *string `json:"following_url,omitempty"`
+	GistsURL          *string `json:"gists_url,omitempty"`
+	StarredURL        *string `json:"starred_url,omitempty"`
+	SubscriptionsURL  *string `json:"subscriptions_url,omitempty"`
+	OrganizationsURL  *string `json:"organizations_url,omitempty"`
+	ReposURL          *string `json:"repos_url,omitempty"`
+	EventsURL         *string `json:"events_url,omitempty"`
+	ReceivedEventsURL *string `json:"received_events_url,omitempty"`
+	Type              *string `json:"type,omitempty"`
+	SiteAdmin         *bool   `json:"site_admin"`
+	Contributions     *int    `json:"contributions,omitempty"`
+}
+
+// ListContributorsOptions specifies the optional parameters to the
+// RepositoriesService.ListContributors method.
+type ListContributorsOptions struct {
+	// Include anonymous contributors in results or not
+	Anon string `url:"anon,omitempty"`
+
+	ListOptions
+}
+
+// ListContributors lists contributors for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#list-contributors
+func (s *RepositoriesService) ListContributors(owner string, repository string, opt *ListContributorsOptions) ([]*Contributor, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/contributors", owner, repository)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contributor := new([]*Contributor)
+	resp, err := s.client.Do(req, contributor)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return *contributor, resp, err
+}
+
+// ListLanguages lists languages for the specified repository. The returned map
+// specifies the languages and the number of bytes of code written in that
+// language. For example:
+//
+//     {
+//       "C": 78769,
+//       "Python": 7769
+//     }
+//
+// GitHub API Docs: http://developer.github.com/v3/repos/#list-languages
+func (s *RepositoriesService) ListLanguages(owner string, repo string) (map[string]int, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/languages", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	languages := make(map[string]int)
+	resp, err := s.client.Do(req, &languages)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return languages, resp, err
+}
+
+// ListTeams lists the teams for the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#list-teams
+func (s *RepositoriesService) ListTeams(owner string, repo string, opt *ListOptions) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/teams", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	teams := new([]*Team)
+	resp, err := s.client.Do(req, teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *teams, resp, err
+}
+
+// RepositoryTag represents a repository tag.
+type RepositoryTag struct {
+	Name       *string `json:"name,omitempty"`
+	Commit     *Commit `json:"commit,omitempty"`
+	ZipballURL *string `json:"zipball_url,omitempty"`
+	TarballURL *string `json:"tarball_url,omitempty"`
+}
+
+// ListTags lists tags for the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#list-tags
+func (s *RepositoriesService) ListTags(owner string, repo string, opt *ListOptions) ([]*RepositoryTag, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/tags", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tags := new([]*RepositoryTag)
+	resp, err := s.client.Do(req, tags)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *tags, resp, err
+}
+
+// Branch represents a repository branch
+type Branch struct {
+	Name       *string     `json:"name,omitempty"`
+	Commit     *Commit     `json:"commit,omitempty"`
+	Protection *Protection `json:"protection,omitempty"`
+}
+
+// Protection represents a repository branch's protection
+type Protection struct {
+	Enabled              *bool                 `json:"enabled,omitempty"`
+	RequiredStatusChecks *RequiredStatusChecks `json:"required_status_checks,omitempty"`
+}
+
+// RequiredStatusChecks represents the protection status of a individual branch
+type RequiredStatusChecks struct {
+	// Who required status checks apply to.
+	// Possible values are:
+	//     off
+	//     non_admins
+	//     everyone
+	EnforcementLevel *string `json:"enforcement_level,omitempty"`
+	// The list of status checks which are required
+	Contexts *[]string `json:"contexts,omitempty"`
+}
+
+// ListBranches lists branches for the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/#list-branches
+func (s *RepositoriesService) ListBranches(owner string, repo string, opt *ListOptions) ([]*Branch, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+
+	branches := new([]*Branch)
+	resp, err := s.client.Do(req, branches)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *branches, resp, err
+}
+
+// GetBranch gets the specified branch for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#get-branch
+func (s *RepositoriesService) GetBranch(owner, repo, branch string) (*Branch, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches/%v", owner, repo, branch)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+
+	b := new(Branch)
+	resp, err := s.client.Do(req, b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
+}
+
+// EditBranch edits the branch (currently only Branch Protection)
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#enabling-and-disabling-branch-protection
+func (s *RepositoriesService) EditBranch(owner, repo, branchName string, branch *Branch) (*Branch, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/branches/%v", owner, repo, branchName)
+	req, err := s.client.NewRequest("PATCH", u, branch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeProtectedBranchesPreview)
+
+	b := new(Branch)
+	resp, err := s.client.Do(req, b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
+}
+
+// License gets the contents of a repository's license if one is detected.
+//
+// GitHub API docs: https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license
+func (s *RepositoriesService) License(owner, repo string) (*License, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/license", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := &Repository{}
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r.License, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_collaborators.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_collaborators.go
@@ -1,0 +1,92 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ListCollaborators lists the Github users that have access to the repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/collaborators/#list
+func (s *RepositoriesService) ListCollaborators(owner, repo string, opt *ListOptions) ([]*User, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	users := new([]*User)
+	resp, err := s.client.Do(req, users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *users, resp, err
+}
+
+// IsCollaborator checks whether the specified Github user has collaborator
+// access to the given repo.
+// Note: This will return false if the user is not a collaborator OR the user
+// is not a GitHub user.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/collaborators/#get
+func (s *RepositoriesService) IsCollaborator(owner, repo, user string) (bool, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	isCollab, err := parseBoolResponse(err)
+	return isCollab, resp, err
+}
+
+// RepositoryAddCollaboratorOptions specifies the optional parameters to the
+// RepositoriesService.AddCollaborator method.
+type RepositoryAddCollaboratorOptions struct {
+	// Permission specifies the permission to grant the user on this repository.
+	// Possible values are:
+	//     pull - team members can pull, but not push to or administer this repository
+	//     push - team members can pull and push, but not administer this repository
+	//     admin - team members can pull, push and administer this repository
+	//
+	// Default value is "push".  This option is only valid for organization-owned repositories.
+	Permission string `json:"permission,omitempty"`
+}
+
+// AddCollaborator adds the specified Github user as collaborator to the given repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
+func (s *RepositoriesService) AddCollaborator(owner, repo, user string, opt *RepositoryAddCollaboratorOptions) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveCollaborator removes the specified Github user as collaborator from the given repo.
+// Note: Does not return error if a valid user that is not a collaborator is removed.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/collaborators/#remove-collaborator
+func (s *RepositoriesService) RemoveCollaborator(owner, repo, user string) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/collaborators/%v", owner, repo, user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_comments.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_comments.go
@@ -1,0 +1,160 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// RepositoryComment represents a comment for a commit, file, or line in a repository.
+type RepositoryComment struct {
+	HTMLURL   *string    `json:"html_url,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	ID        *int       `json:"id,omitempty"`
+	CommitID  *string    `json:"commit_id,omitempty"`
+	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+
+	// User-mutable fields
+	Body *string `json:"body"`
+	// User-initialized fields
+	Path     *string `json:"path,omitempty"`
+	Position *int    `json:"position,omitempty"`
+}
+
+func (r RepositoryComment) String() string {
+	return Stringify(r)
+}
+
+// ListComments lists all the comments for the repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
+func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions) ([]*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comments := new([]*RepositoryComment)
+	resp, err := s.client.Do(req, comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *comments, resp, err
+}
+
+// ListCommitComments lists all the comments for a given commit SHA.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
+func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *ListOptions) ([]*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	comments := new([]*RepositoryComment)
+	resp, err := s.client.Do(req, comments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *comments, resp, err
+}
+
+// CreateComment creates a comment for the given commit.
+// Note: GitHub allows for comments to be created for non-existing files and positions.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#create-a-commit-comment
+func (s *RepositoriesService) CreateComment(owner, repo, sha string, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v/comments", owner, repo, sha)
+	req, err := s.client.NewRequest("POST", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(RepositoryComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// GetComment gets a single comment from a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
+func (s *RepositoriesService) GetComment(owner, repo string, id int) (*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	c := new(RepositoryComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// UpdateComment updates the body of a single comment.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#update-a-commit-comment
+func (s *RepositoriesService) UpdateComment(owner, repo string, id int, comment *RepositoryComment) (*RepositoryComment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := new(RepositoryComment)
+	resp, err := s.client.Do(req, c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}
+
+// DeleteComment deletes a single comment from a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/comments/#delete-a-commit-comment
+func (s *RepositoriesService) DeleteComment(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v", owner, repo, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_commits.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_commits.go
@@ -1,0 +1,198 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+)
+
+// RepositoryCommit represents a commit in a repo.
+// Note that it's wrapping a Commit, so author/committer information is in two places,
+// but contain different details about them: in RepositoryCommit "github details", in Commit - "git details".
+type RepositoryCommit struct {
+	SHA       *string  `json:"sha,omitempty"`
+	Commit    *Commit  `json:"commit,omitempty"`
+	Author    *User    `json:"author,omitempty"`
+	Committer *User    `json:"committer,omitempty"`
+	Parents   []Commit `json:"parents,omitempty"`
+	Message   *string  `json:"message,omitempty"`
+	HTMLURL   *string  `json:"html_url,omitempty"`
+
+	// Details about how many changes were made in this commit. Only filled in during GetCommit!
+	Stats *CommitStats `json:"stats,omitempty"`
+	// Details about which files, and how this commit touched. Only filled in during GetCommit!
+	Files []CommitFile `json:"files,omitempty"`
+}
+
+func (r RepositoryCommit) String() string {
+	return Stringify(r)
+}
+
+// CommitStats represents the number of additions / deletions from a file in a given RepositoryCommit or GistCommit.
+type CommitStats struct {
+	Additions *int `json:"additions,omitempty"`
+	Deletions *int `json:"deletions,omitempty"`
+	Total     *int `json:"total,omitempty"`
+}
+
+func (c CommitStats) String() string {
+	return Stringify(c)
+}
+
+// CommitFile represents a file modified in a commit.
+type CommitFile struct {
+	SHA       *string `json:"sha,omitempty"`
+	Filename  *string `json:"filename,omitempty"`
+	Additions *int    `json:"additions,omitempty"`
+	Deletions *int    `json:"deletions,omitempty"`
+	Changes   *int    `json:"changes,omitempty"`
+	Status    *string `json:"status,omitempty"`
+	Patch     *string `json:"patch,omitempty"`
+}
+
+func (c CommitFile) String() string {
+	return Stringify(c)
+}
+
+// CommitsComparison is the result of comparing two commits.
+// See CompareCommits() for details.
+type CommitsComparison struct {
+	BaseCommit      *RepositoryCommit `json:"base_commit,omitempty"`
+	MergeBaseCommit *RepositoryCommit `json:"merge_base_commit,omitempty"`
+
+	// Head can be 'behind' or 'ahead'
+	Status       *string `json:"status,omitempty"`
+	AheadBy      *int    `json:"ahead_by,omitempty"`
+	BehindBy     *int    `json:"behind_by,omitempty"`
+	TotalCommits *int    `json:"total_commits,omitempty"`
+
+	Commits []RepositoryCommit `json:"commits,omitempty"`
+
+	Files []CommitFile `json:"files,omitempty"`
+}
+
+func (c CommitsComparison) String() string {
+	return Stringify(c)
+}
+
+// CommitsListOptions specifies the optional parameters to the
+// RepositoriesService.ListCommits method.
+type CommitsListOptions struct {
+	// SHA or branch to start listing Commits from.
+	SHA string `url:"sha,omitempty"`
+
+	// Path that should be touched by the returned Commits.
+	Path string `url:"path,omitempty"`
+
+	// Author of by which to filter Commits.
+	Author string `url:"author,omitempty"`
+
+	// Since when should Commits be included in the response.
+	Since time.Time `url:"since,omitempty"`
+
+	// Until when should Commits be included in the response.
+	Until time.Time `url:"until,omitempty"`
+
+	ListOptions
+}
+
+// ListCommits lists the commits of a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/commits/#list
+func (s *RepositoriesService) ListCommits(owner, repo string, opt *CommitsListOptions) ([]*RepositoryCommit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	commits := new([]*RepositoryCommit)
+	resp, err := s.client.Do(req, commits)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *commits, resp, err
+}
+
+// GetCommit fetches the specified commit, including all details about it.
+// todo: support media formats - https://github.com/google/go-github/issues/6
+//
+// GitHub API docs: http://developer.github.com/v3/repos/commits/#get-a-single-commit
+// See also: http://developer.github.com//v3/git/commits/#get-a-single-commit provides the same functionality
+func (s *RepositoriesService) GetCommit(owner, repo, sha string) (*RepositoryCommit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	commit := new(RepositoryCommit)
+	resp, err := s.client.Do(req, commit)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return commit, resp, err
+}
+
+// GetCommitSHA1 gets the SHA-1 of a commit reference.  If a last-known SHA1 is
+// supplied and no new commits have occurred, a 304 Unmodified response is returned.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference
+func (s *RepositoriesService) GetCommitSHA1(owner, repo, ref, lastSHA string) (string, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, ref)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	if lastSHA != "" {
+		req.Header.Set("If-None-Match", `"`+lastSHA+`"`)
+	}
+
+	req.Header.Set("Accept", mediaTypeV3SHA)
+
+	var buf bytes.Buffer
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, err
+}
+
+// CompareCommits compares a range of commits with each other.
+// todo: support media formats - https://github.com/google/go-github/issues/6
+//
+// GitHub API docs: http://developer.github.com/v3/repos/commits/index.html#compare-two-commits
+func (s *RepositoriesService) CompareCommits(owner, repo string, base, head string) (*CommitsComparison, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/compare/%v...%v", owner, repo, base, head)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	comp := new(CommitsComparison)
+	resp, err := s.client.Do(req, comp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return comp, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_contents.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_contents.go
@@ -1,0 +1,275 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Repository contents API methods.
+// http://developer.github.com/v3/repos/contents/
+
+package github
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+// RepositoryContent represents a file or directory in a github repository.
+type RepositoryContent struct {
+	Type     *string `json:"type,omitempty"`
+	Encoding *string `json:"encoding,omitempty"`
+	Size     *int    `json:"size,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Path     *string `json:"path,omitempty"`
+	// Content contains the actual file content, which may be encoded.
+	// Callers should call GetContent which will decode the content if
+	// necessary.
+	Content     *string `json:"content,omitempty"`
+	SHA         *string `json:"sha,omitempty"`
+	URL         *string `json:"url,omitempty"`
+	GitURL      *string `json:"git_url,omitempty"`
+	HTMLURL     *string `json:"html_url,omitempty"`
+	DownloadURL *string `json:"download_url,omitempty"`
+}
+
+// RepositoryContentResponse holds the parsed response from CreateFile, UpdateFile, and DeleteFile.
+type RepositoryContentResponse struct {
+	Content *RepositoryContent `json:"content,omitempty"`
+	Commit  `json:"commit,omitempty"`
+}
+
+// RepositoryContentFileOptions specifies optional parameters for CreateFile, UpdateFile, and DeleteFile.
+type RepositoryContentFileOptions struct {
+	Message   *string       `json:"message,omitempty"`
+	Content   []byte        `json:"content,omitempty"` // unencoded
+	SHA       *string       `json:"sha,omitempty"`
+	Branch    *string       `json:"branch,omitempty"`
+	Author    *CommitAuthor `json:"author,omitempty"`
+	Committer *CommitAuthor `json:"committer,omitempty"`
+}
+
+// RepositoryContentGetOptions represents an optional ref parameter, which can be a SHA,
+// branch, or tag
+type RepositoryContentGetOptions struct {
+	Ref string `url:"ref,omitempty"`
+}
+
+// String converts RepositoryContent to a string. It's primarily for testing.
+func (r RepositoryContent) String() string {
+	return Stringify(r)
+}
+
+// Decode decodes the file content if it is base64 encoded.
+//
+// Deprecated: Use GetContent instead.
+func (r *RepositoryContent) Decode() ([]byte, error) {
+	if *r.Encoding != "base64" {
+		return nil, errors.New("cannot decode non-base64")
+	}
+	o, err := base64.StdEncoding.DecodeString(*r.Content)
+	if err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+// GetContent returns the content of r, decoding it if necessary.
+func (r *RepositoryContent) GetContent() (string, error) {
+	var encoding string
+	if r.Encoding != nil {
+		encoding = *r.Encoding
+	}
+
+	switch encoding {
+	case "base64":
+		c, err := base64.StdEncoding.DecodeString(*r.Content)
+		return string(c), err
+	case "":
+		if r.Content == nil {
+			return "", nil
+		}
+		return *r.Content, nil
+	default:
+		return "", fmt.Errorf("unsupported content encoding: %v", encoding)
+	}
+}
+
+// GetReadme gets the Readme file for the repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#get-the-readme
+func (s *RepositoriesService) GetReadme(owner, repo string, opt *RepositoryContentGetOptions) (*RepositoryContent, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/readme", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	readme := new(RepositoryContent)
+	resp, err := s.client.Do(req, readme)
+	if err != nil {
+		return nil, resp, err
+	}
+	return readme, resp, err
+}
+
+// DownloadContents returns an io.ReadCloser that reads the contents of the
+// specified file. This function will work with files of any size, as opposed
+// to GetContents which is limited to 1 Mb files. It is the caller's
+// responsibility to close the ReadCloser.
+func (s *RepositoriesService) DownloadContents(owner, repo, filepath string, opt *RepositoryContentGetOptions) (io.ReadCloser, error) {
+	dir := path.Dir(filepath)
+	filename := path.Base(filepath)
+	_, dirContents, _, err := s.GetContents(owner, repo, dir, opt)
+	if err != nil {
+		return nil, err
+	}
+	for _, contents := range dirContents {
+		if *contents.Name == filename {
+			if contents.DownloadURL == nil || *contents.DownloadURL == "" {
+				return nil, fmt.Errorf("No download link found for %s", filepath)
+			}
+			resp, err := s.client.client.Get(*contents.DownloadURL)
+			if err != nil {
+				return nil, err
+			}
+			return resp.Body, nil
+		}
+	}
+	return nil, fmt.Errorf("No file named %s found in %s", filename, dir)
+}
+
+// GetContents can return either the metadata and content of a single file
+// (when path references a file) or the metadata of all the files and/or
+// subdirectories of a directory (when path references a directory). To make it
+// easy to distinguish between both result types and to mimic the API as much
+// as possible, both result types will be returned but only one will contain a
+// value and the other will be nil.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#get-contents
+func (s *RepositoriesService) GetContents(owner, repo, path string, opt *RepositoryContentGetOptions) (fileContent *RepositoryContent, directoryContent []*RepositoryContent, resp *Response, err error) {
+	escapedPath := (&url.URL{Path: path}).String()
+	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, escapedPath)
+	u, err = addOptions(u, opt)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var rawJSON json.RawMessage
+	resp, err = s.client.Do(req, &rawJSON)
+	if err != nil {
+		return nil, nil, resp, err
+	}
+	fileUnmarshalError := json.Unmarshal(rawJSON, &fileContent)
+	if fileUnmarshalError == nil {
+		return fileContent, nil, resp, fileUnmarshalError
+	}
+	directoryUnmarshalError := json.Unmarshal(rawJSON, &directoryContent)
+	if directoryUnmarshalError == nil {
+		return nil, directoryContent, resp, directoryUnmarshalError
+	}
+	return nil, nil, resp, fmt.Errorf("unmarshalling failed for both file and directory content: %s and %s ", fileUnmarshalError, directoryUnmarshalError)
+}
+
+// CreateFile creates a new file in a repository at the given path and returns
+// the commit and file metadata.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#create-a-file
+func (s *RepositoriesService) CreateFile(owner, repo, path string, opt *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	createResponse := new(RepositoryContentResponse)
+	resp, err := s.client.Do(req, createResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+	return createResponse, resp, err
+}
+
+// UpdateFile updates a file in a repository at the given path and returns the
+// commit and file metadata. Requires the blob SHA of the file being updated.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#update-a-file
+func (s *RepositoriesService) UpdateFile(owner, repo, path string, opt *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	req, err := s.client.NewRequest("PUT", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	updateResponse := new(RepositoryContentResponse)
+	resp, err := s.client.Do(req, updateResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+	return updateResponse, resp, err
+}
+
+// DeleteFile deletes a file from a repository and returns the commit.
+// Requires the blob SHA of the file to be deleted.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#delete-a-file
+func (s *RepositoriesService) DeleteFile(owner, repo, path string, opt *RepositoryContentFileOptions) (*RepositoryContentResponse, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)
+	req, err := s.client.NewRequest("DELETE", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	deleteResponse := new(RepositoryContentResponse)
+	resp, err := s.client.Do(req, deleteResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+	return deleteResponse, resp, err
+}
+
+// archiveFormat is used to define the archive type when calling GetArchiveLink.
+type archiveFormat string
+
+const (
+	// Tarball specifies an archive in gzipped tar format.
+	Tarball archiveFormat = "tarball"
+
+	// Zipball specifies an archive in zip format.
+	Zipball archiveFormat = "zipball"
+)
+
+// GetArchiveLink returns an URL to download a tarball or zipball archive for a
+// repository. The archiveFormat can be specified by either the github.Tarball
+// or github.Zipball constant.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/contents/#get-archive-link
+func (s *RepositoriesService) GetArchiveLink(owner, repo string, archiveformat archiveFormat, opt *RepositoryContentGetOptions) (*url.URL, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/%s", owner, repo, archiveformat)
+	if opt != nil && opt.Ref != "" {
+		u += fmt.Sprintf("/%s", opt.Ref)
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var resp *http.Response
+	// Use http.DefaultTransport if no custom Transport is configured
+	if s.client.client.Transport == nil {
+		resp, err = http.DefaultTransport.RoundTrip(req)
+	} else {
+		resp, err = s.client.client.Transport.RoundTrip(req)
+	}
+	if err != nil || resp.StatusCode != http.StatusFound {
+		return nil, newResponse(resp), err
+	}
+	parsedURL, err := url.Parse(resp.Header.Get("Location"))
+	return parsedURL, newResponse(resp), err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_deployments.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_deployments.go
@@ -1,0 +1,179 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Deployment represents a deployment in a repo
+type Deployment struct {
+	URL           *string         `json:"url,omitempty"`
+	ID            *int            `json:"id,omitempty"`
+	SHA           *string         `json:"sha,omitempty"`
+	Ref           *string         `json:"ref,omitempty"`
+	Task          *string         `json:"task,omitempty"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+	Environment   *string         `json:"environment,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Creator       *User           `json:"creator,omitempty"`
+	CreatedAt     *Timestamp      `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp      `json:"pushed_at,omitempty"`
+	StatusesURL   *string         `json:"statuses_url,omitempty"`
+	RepositoryURL *string         `json:"repository_url,omitempty"`
+}
+
+// DeploymentRequest represents a deployment request
+type DeploymentRequest struct {
+	Ref                   *string   `json:"ref,omitempty"`
+	Task                  *string   `json:"task,omitempty"`
+	AutoMerge             *bool     `json:"auto_merge,omitempty"`
+	RequiredContexts      *[]string `json:"required_contexts,omitempty"`
+	Payload               *string   `json:"payload,omitempty"`
+	Environment           *string   `json:"environment,omitempty"`
+	Description           *string   `json:"description,omitempty"`
+	TransientEnvironment  *bool     `json:"transient_environment,omitempty"`
+	ProductionEnvironment *bool     `json:"production_environment,omitempty"`
+}
+
+// DeploymentsListOptions specifies the optional parameters to the
+// RepositoriesService.ListDeployments method.
+type DeploymentsListOptions struct {
+	// SHA of the Deployment.
+	SHA string `url:"sha,omitempty"`
+
+	// List deployments for a given ref.
+	Ref string `url:"ref,omitempty"`
+
+	// List deployments for a given task.
+	Task string `url:"task,omitempty"`
+
+	// List deployments for a given environment.
+	Environment string `url:"environment,omitempty"`
+
+	ListOptions
+}
+
+// ListDeployments lists the deployments of a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#list-deployments
+func (s *RepositoriesService) ListDeployments(owner, repo string, opt *DeploymentsListOptions) ([]*Deployment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deployments := new([]*Deployment)
+	resp, err := s.client.Do(req, deployments)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *deployments, resp, err
+}
+
+// CreateDeployment creates a new deployment for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#create-a-deployment
+func (s *RepositoriesService) CreateDeployment(owner, repo string, request *DeploymentRequest) (*Deployment, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when deployment support fully launches
+	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+
+	d := new(Deployment)
+	resp, err := s.client.Do(req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}
+
+// DeploymentStatus represents the status of a
+// particular deployment.
+type DeploymentStatus struct {
+	ID *int `json:"id,omitempty"`
+	// State is the deployment state.
+	// Possible values are: "pending", "success", "failure", "error", "inactive".
+	State         *string    `json:"state,omitempty"`
+	Creator       *User      `json:"creator,omitempty"`
+	Description   *string    `json:"description,omitempty"`
+	TargetURL     *string    `json:"target_url,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt     *Timestamp `json:"pushed_at,omitempty"`
+	DeploymentURL *string    `json:"deployment_url,omitempty"`
+	RepositoryURL *string    `json:"repository_url,omitempty"`
+}
+
+// DeploymentStatusRequest represents a deployment request
+type DeploymentStatusRequest struct {
+	State          *string `json:"state,omitempty"`
+	TargetURL      *string `json:"target_url,omitempty"` // Deprecated. Use LogURL instead.
+	LogURL         *string `json:"log_url,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	EnvironmentURL *string `json:"environment_url,omitempty"`
+	AutoInactive   *bool   `json:"auto_inactive,omitempty"`
+}
+
+// ListDeploymentStatuses lists the statuses of a given deployment of a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+func (s *RepositoriesService) ListDeploymentStatuses(owner, repo string, deployment int, opt *ListOptions) ([]*DeploymentStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statuses := new([]*DeploymentStatus)
+	resp, err := s.client.Do(req, statuses)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *statuses, resp, err
+}
+
+// CreateDeploymentStatus creates a new status for a deployment.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+func (s *RepositoriesService) CreateDeploymentStatus(owner, repo string, deployment int, request *DeploymentStatusRequest) (*DeploymentStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments/%v/statuses", owner, repo, deployment)
+
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when deployment support fully launches
+	req.Header.Set("Accept", mediaTypeDeploymentStatusPreview)
+
+	d := new(DeploymentStatus)
+	resp, err := s.client.Do(req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_forks.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_forks.go
@@ -1,0 +1,73 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// RepositoryListForksOptions specifies the optional parameters to the
+// RepositoriesService.ListForks method.
+type RepositoryListForksOptions struct {
+	// How to sort the forks list.  Possible values are: newest, oldest,
+	// watchers.  Default is "newest".
+	Sort string `url:"sort,omitempty"`
+
+	ListOptions
+}
+
+// ListForks lists the forks of the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/forks/#list-forks
+func (s *RepositoriesService) ListForks(owner, repo string, opt *RepositoryListForksOptions) ([]*Repository, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repos := new([]*Repository)
+	resp, err := s.client.Do(req, repos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *repos, resp, err
+}
+
+// RepositoryCreateForkOptions specifies the optional parameters to the
+// RepositoriesService.CreateFork method.
+type RepositoryCreateForkOptions struct {
+	// The organization to fork the repository into.
+	Organization string `url:"organization,omitempty"`
+}
+
+// CreateFork creates a fork of the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/forks/#create-a-fork
+func (s *RepositoriesService) CreateFork(owner, repo string, opt *RepositoryCreateForkOptions) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/forks", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fork := new(Repository)
+	resp, err := s.client.Do(req, fork)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return fork, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_hooks.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_hooks.go
@@ -1,0 +1,196 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// WebHookPayload represents the data that is received from GitHub when a push
+// event hook is triggered.  The format of these payloads pre-date most of the
+// GitHub v3 API, so there are lots of minor incompatibilities with the types
+// defined in the rest of the API.  Therefore, several types are duplicated
+// here to account for these differences.
+//
+// GitHub API docs: https://help.github.com/articles/post-receive-hooks
+type WebHookPayload struct {
+	After      *string         `json:"after,omitempty"`
+	Before     *string         `json:"before,omitempty"`
+	Commits    []WebHookCommit `json:"commits,omitempty"`
+	Compare    *string         `json:"compare,omitempty"`
+	Created    *bool           `json:"created,omitempty"`
+	Deleted    *bool           `json:"deleted,omitempty"`
+	Forced     *bool           `json:"forced,omitempty"`
+	HeadCommit *WebHookCommit  `json:"head_commit,omitempty"`
+	Pusher     *User           `json:"pusher,omitempty"`
+	Ref        *string         `json:"ref,omitempty"`
+	Repo       *Repository     `json:"repository,omitempty"`
+	Sender     *User           `json:"sender,omitempty"`
+}
+
+func (w WebHookPayload) String() string {
+	return Stringify(w)
+}
+
+// WebHookCommit represents the commit variant we receive from GitHub in a
+// WebHookPayload.
+type WebHookCommit struct {
+	Added     []string       `json:"added,omitempty"`
+	Author    *WebHookAuthor `json:"author,omitempty"`
+	Committer *WebHookAuthor `json:"committer,omitempty"`
+	Distinct  *bool          `json:"distinct,omitempty"`
+	ID        *string        `json:"id,omitempty"`
+	Message   *string        `json:"message,omitempty"`
+	Modified  []string       `json:"modified,omitempty"`
+	Removed   []string       `json:"removed,omitempty"`
+	Timestamp *time.Time     `json:"timestamp,omitempty"`
+}
+
+func (w WebHookCommit) String() string {
+	return Stringify(w)
+}
+
+// WebHookAuthor represents the author or committer of a commit, as specified
+// in a WebHookCommit.  The commit author may not correspond to a GitHub User.
+type WebHookAuthor struct {
+	Email    *string `json:"email,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Username *string `json:"username,omitempty"`
+}
+
+func (w WebHookAuthor) String() string {
+	return Stringify(w)
+}
+
+// Hook represents a GitHub (web and service) hook for a repository.
+type Hook struct {
+	CreatedAt *time.Time             `json:"created_at,omitempty"`
+	UpdatedAt *time.Time             `json:"updated_at,omitempty"`
+	Name      *string                `json:"name,omitempty"`
+	URL       *string                `json:"url,omitempty"`
+	Events    []string               `json:"events,omitempty"`
+	Active    *bool                  `json:"active,omitempty"`
+	Config    map[string]interface{} `json:"config,omitempty"`
+	ID        *int                   `json:"id,omitempty"`
+}
+
+func (h Hook) String() string {
+	return Stringify(h)
+}
+
+// CreateHook creates a Hook for the specified repository.
+// Name and Config are required fields.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#create-a-hook
+func (s *RepositoriesService) CreateHook(owner, repo string, hook *Hook) (*Hook, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
+	req, err := s.client.NewRequest("POST", u, hook)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	h := new(Hook)
+	resp, err := s.client.Do(req, h)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return h, resp, err
+}
+
+// ListHooks lists all Hooks for the specified repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#list
+func (s *RepositoriesService) ListHooks(owner, repo string, opt *ListOptions) ([]*Hook, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hooks := new([]*Hook)
+	resp, err := s.client.Do(req, hooks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *hooks, resp, err
+}
+
+// GetHook returns a single specified Hook.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#get-single-hook
+func (s *RepositoriesService) GetHook(owner, repo string, id int) (*Hook, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	hook := new(Hook)
+	resp, err := s.client.Do(req, hook)
+	return hook, resp, err
+}
+
+// EditHook updates a specified Hook.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#edit-a-hook
+func (s *RepositoriesService) EditHook(owner, repo string, id int, hook *Hook) (*Hook, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	req, err := s.client.NewRequest("PATCH", u, hook)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := new(Hook)
+	resp, err := s.client.Do(req, h)
+	return h, resp, err
+}
+
+// DeleteHook deletes a specified Hook.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#delete-a-hook
+func (s *RepositoriesService) DeleteHook(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d", owner, repo, id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// PingHook triggers a 'ping' event to be sent to the Hook.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/hooks/#ping-a-hook
+func (s *RepositoriesService) PingHook(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/pings", owner, repo, id)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// TestHook triggers a test Hook by github.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/hooks/#test-a-push-hook
+func (s *RepositoriesService) TestHook(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/hooks/%d/tests", owner, repo, id)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ListServiceHooks is deprecated.  Use Client.ListServiceHooks instead.
+func (s *RepositoriesService) ListServiceHooks() ([]*ServiceHook, *Response, error) {
+	return s.client.ListServiceHooks()
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_invitations.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_invitations.go
@@ -1,0 +1,91 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// RepositoryInvitation represents an invitation to collaborate on a repo.
+type RepositoryInvitation struct {
+	ID      *int        `json:"id,omitempty"`
+	Repo    *Repository `json:"repository,omitempty"`
+	Invitee *User       `json:"invitee,omitempty"`
+	Inviter *User       `json:"inviter,omitempty"`
+
+	// Permissions represents the permissions that the associated user will have
+	// on the repository. Possible values are: "read", "write", "admin".
+	Permissions *string    `json:"permissions,omitempty"`
+	CreatedAt   *Timestamp `json:"created_at,omitempty"`
+	URL         *string    `json:"url,omitempty"`
+	HTMLURL     *string    `json:"html_url,omitempty"`
+}
+
+// ListInvitations lists all currently-open repository invitations.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository
+func (s *RepositoriesService) ListInvitations(repoID int, opt *ListOptions) ([]*RepositoryInvitation, *Response, error) {
+	u := fmt.Sprintf("repositories/%v/invitations", repoID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	invites := []*RepositoryInvitation{}
+	resp, err := s.client.Do(req, &invites)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return invites, resp, err
+}
+
+// DeleteInvitation deletes a repository invitation.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation
+func (s *RepositoriesService) DeleteInvitation(repoID, invitationID int) (*Response, error) {
+	u := fmt.Sprintf("repositories/%v/invitations/%v", repoID, invitationID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateInvitation updates the permissions associated with a repository
+// invitation.
+//
+// permissions represents the permissions that the associated user will have
+// on the repository. Possible values are: "read", "write", "admin".
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
+func (s *RepositoriesService) UpdateInvitation(repoID, invitationID int, permissions string) (*RepositoryInvitation, *Response, error) {
+	opts := &struct {
+		Permissions string `json:"permissions"`
+	}{Permissions: permissions}
+	u := fmt.Sprintf("repositories/%v/invitations/%v", repoID, invitationID)
+	req, err := s.client.NewRequest("PATCH", u, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	invite := &RepositoryInvitation{}
+	resp, err := s.client.Do(req, invite)
+	return invite, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_keys.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_keys.go
@@ -1,0 +1,108 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// The Key type is defined in users_keys.go
+
+// ListKeys lists the deploy keys for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/keys/#list
+func (s *RepositoriesService) ListKeys(owner string, repo string, opt *ListOptions) ([]*Key, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keys := new([]*Key)
+	resp, err := s.client.Do(req, keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *keys, resp, err
+}
+
+// GetKey fetches a single deploy key.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/keys/#get
+func (s *RepositoriesService) GetKey(owner string, repo string, id int) (*Key, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key := new(Key)
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// CreateKey adds a deploy key for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/keys/#create
+func (s *RepositoriesService) CreateKey(owner string, repo string, key *Key) (*Key, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/keys", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k := new(Key)
+	resp, err := s.client.Do(req, k)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return k, resp, err
+}
+
+// EditKey edits a deploy key.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/keys/#edit
+func (s *RepositoriesService) EditKey(owner string, repo string, id int, key *Key) (*Key, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
+
+	req, err := s.client.NewRequest("PATCH", u, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k := new(Key)
+	resp, err := s.client.Do(req, k)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return k, resp, err
+}
+
+// DeleteKey deletes a deploy key.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/keys/#delete
+func (s *RepositoriesService) DeleteKey(owner string, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/keys/%v", owner, repo, id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_merging.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_merging.go
@@ -1,0 +1,37 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+)
+
+// RepositoryMergeRequest represents a request to merge a branch in a
+// repository.
+type RepositoryMergeRequest struct {
+	Base          *string `json:"base,omitempty"`
+	Head          *string `json:"head,omitempty"`
+	CommitMessage *string `json:"commit_message,omitempty"`
+}
+
+// Merge a branch in the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/merging/#perform-a-merge
+func (s *RepositoriesService) Merge(owner, repo string, request *RepositoryMergeRequest) (*RepositoryCommit, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/merges", owner, repo)
+	req, err := s.client.NewRequest("POST", u, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	commit := new(RepositoryCommit)
+	resp, err := s.client.Do(req, commit)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return commit, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_pages.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_pages.go
@@ -1,0 +1,116 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Pages represents a GitHub Pages site configuration.
+type Pages struct {
+	URL       *string `json:"url,omitempty"`
+	Status    *string `json:"status,omitempty"`
+	CNAME     *string `json:"cname,omitempty"`
+	Custom404 *bool   `json:"custom_404,omitempty"`
+	HTMLURL   *string `json:"html_url,omitempty"`
+}
+
+// PagesError represents a build error for a GitHub Pages site.
+type PagesError struct {
+	Message *string `json:"message,omitempty"`
+}
+
+// PagesBuild represents the build information for a GitHub Pages site.
+type PagesBuild struct {
+	URL       *string     `json:"url,omitempty"`
+	Status    *string     `json:"status,omitempty"`
+	Error     *PagesError `json:"error,omitempty"`
+	Pusher    *User       `json:"pusher,omitempty"`
+	Commit    *string     `json:"commit,omitempty"`
+	Duration  *int        `json:"duration,omitempty"`
+	CreatedAt *Timestamp  `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp  `json:"created_at,omitempty"`
+}
+
+// GetPagesInfo fetches information about a GitHub Pages site.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site
+func (s *RepositoriesService) GetPagesInfo(owner string, repo string) (*Pages, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypePagesPreview)
+
+	site := new(Pages)
+	resp, err := s.client.Do(req, site)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return site, resp, err
+}
+
+// ListPagesBuilds lists the builds for a GitHub Pages site.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#list-pages-builds
+func (s *RepositoriesService) ListPagesBuilds(owner string, repo string) ([]*PagesBuild, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pages []*PagesBuild
+	resp, err := s.client.Do(req, &pages)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pages, resp, err
+}
+
+// GetLatestPagesBuild fetches the latest build information for a GitHub pages site.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#list-latest-pages-build
+func (s *RepositoriesService) GetLatestPagesBuild(owner string, repo string) (*PagesBuild, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages/builds/latest", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	build := new(PagesBuild)
+	resp, err := s.client.Do(req, build)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return build, resp, err
+}
+
+// RequestPageBuild requests a build of a GitHub Pages site without needing to push new commit.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/pages/#request-a-page-build
+func (s *RepositoriesService) RequestPageBuild(owner string, repo string) (*PagesBuild, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pages/builds", owner, repo)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypePagesPreview)
+
+	build := new(PagesBuild)
+	resp, err := s.client.Do(req, build)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return build, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_projects.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_projects.go
@@ -1,0 +1,464 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+)
+
+// Project represents a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/
+type Project struct {
+	ID        *int       `json:"id,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	OwnerURL  *string    `json:"owner_url,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	Body      *string    `json:"body,omitempty"`
+	Number    *int       `json:"number,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
+
+	// The User object that generated the project.
+	Creator *User `json:"creator,omitempty"`
+}
+
+func (p Project) String() string {
+	return Stringify(p)
+}
+
+// ListProjects lists the projects for a repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#list-projects
+func (s *RepositoriesService) ListProjects(owner, repo string, opt *ListOptions) ([]*Project, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	projects := []*Project{}
+	resp, err := s.client.Do(req, &projects)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return projects, resp, err
+}
+
+// GetProject gets a GitHub Project for a repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#get-a-project
+func (s *RepositoriesService) GetProject(owner, repo string, number int) (*Project, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/%v", owner, repo, number)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	project := &Project{}
+	resp, err := s.client.Do(req, project)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return project, resp, err
+}
+
+// ProjectOptions specifies the parameters to the
+// RepositoriesService.CreateProject and
+// RepositoriesService.UpdateProject methods.
+type ProjectOptions struct {
+	// The name of the project. (Required for creation; optional for update.)
+	Name string `json:"name,omitempty"`
+	// The body of the project. (Optional.)
+	Body string `json:"body,omitempty"`
+}
+
+// CreateProject creates a GitHub Project for the specified repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#create-a-project
+func (s *RepositoriesService) CreateProject(owner, repo string, projectOptions *ProjectOptions) (*Project, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects", owner, repo)
+	req, err := s.client.NewRequest("POST", u, projectOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	project := &Project{}
+	resp, err := s.client.Do(req, project)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return project, resp, err
+}
+
+// UpdateProject updates a repository project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#update-a-project
+func (s *RepositoriesService) UpdateProject(owner, repo string, number int, projectOptions *ProjectOptions) (*Project, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/%v", owner, repo, number)
+	req, err := s.client.NewRequest("PATCH", u, projectOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	project := &Project{}
+	resp, err := s.client.Do(req, project)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return project, resp, err
+}
+
+// DeleteProject deletes a GitHub Project from a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#delete-a-project
+func (s *RepositoriesService) DeleteProject(owner, repo string, number int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/%v", owner, repo, number)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// ProjectColumn represents a column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/
+type ProjectColumn struct {
+	ID         *int       `json:"id,omitempty"`
+	Name       *string    `json:"name,omitempty"`
+	ProjectURL *string    `json:"project_url,omitempty"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+}
+
+// ListProjectColumns lists the columns of a GitHub Project for a repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#list-columns
+func (s *RepositoriesService) ListProjectColumns(owner, repo string, number int, opt *ListOptions) ([]*ProjectColumn, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/%v/columns", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	columns := []*ProjectColumn{}
+	resp, err := s.client.Do(req, &columns)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return columns, resp, err
+}
+
+// GetProjectColumn gets a column of a GitHub Project for a repo.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#get-a-column
+func (s *RepositoriesService) GetProjectColumn(owner, repo string, columnID int) (*ProjectColumn, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v", owner, repo, columnID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	column := &ProjectColumn{}
+	resp, err := s.client.Do(req, column)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return column, resp, err
+}
+
+// ProjectColumnOptions specifies the parameters to the
+// RepositoriesService.CreateProjectColumn and
+// RepositoriesService.UpdateProjectColumn methods.
+type ProjectColumnOptions struct {
+	// The name of the project column. (Required for creation and update.)
+	Name string `json:"name"`
+}
+
+// CreateProjectColumn creates a column for the specified (by number) project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#create-a-column
+func (s *RepositoriesService) CreateProjectColumn(owner, repo string, number int, columnOptions *ProjectColumnOptions) (*ProjectColumn, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/%v/columns", owner, repo, number)
+	req, err := s.client.NewRequest("POST", u, columnOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	column := &ProjectColumn{}
+	resp, err := s.client.Do(req, column)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return column, resp, err
+}
+
+// UpdateProjectColumn updates a column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#update-a-column
+func (s *RepositoriesService) UpdateProjectColumn(owner, repo string, columnID int, columnOptions *ProjectColumnOptions) (*ProjectColumn, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v", owner, repo, columnID)
+	req, err := s.client.NewRequest("PATCH", u, columnOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	column := &ProjectColumn{}
+	resp, err := s.client.Do(req, column)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return column, resp, err
+}
+
+// DeleteProjectColumn deletes a column from a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#delete-a-column
+func (s *RepositoriesService) DeleteProjectColumn(owner, repo string, columnID int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v", owner, repo, columnID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// ProjectColumnMoveOptions specifies the parameters to the
+// RepositoriesService.MoveProjectColumn method.
+type ProjectColumnMoveOptions struct {
+	// Position can be one of "first", "last", or "after:<column-id>", where
+	// <column-id> is the ID of a column in the same project. (Required.)
+	Position string `json:"position"`
+}
+
+// MoveProjectColumn moves a column within a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#move-a-column
+func (s *RepositoriesService) MoveProjectColumn(owner, repo string, columnID int, moveOptions *ProjectColumnMoveOptions) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v/moves", owner, repo, columnID)
+	req, err := s.client.NewRequest("POST", u, moveOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// ProjectCard represents a card in a column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/
+type ProjectCard struct {
+	ColumnURL  *string    `json:"column_url,omitempty"`
+	ContentURL *string    `json:"content_url,omitempty"`
+	ID         *int       `json:"id,omitempty"`
+	Note       *string    `json:"note,omitempty"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+}
+
+// ListProjectCards lists the cards in a column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#list-projects-cards
+func (s *RepositoriesService) ListProjectCards(owner, repo string, columnID int, opt *ListOptions) ([]*ProjectCard, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v/cards", owner, repo, columnID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	cards := []*ProjectCard{}
+	resp, err := s.client.Do(req, &cards)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return cards, resp, err
+}
+
+// GetProjectCard gets a card in a column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#get-a-project-card
+func (s *RepositoriesService) GetProjectCard(owner, repo string, columnID int) (*ProjectCard, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/cards/%v", owner, repo, columnID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	card := &ProjectCard{}
+	resp, err := s.client.Do(req, card)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return card, resp, err
+}
+
+// ProjectCardOptions specifies the parameters to the
+// RepositoriesService.CreateProjectCard and
+// RepositoriesService.UpdateProjectCard methods.
+type ProjectCardOptions struct {
+	// The note of the card. Note and ContentID are mutually exclusive.
+	Note string `json:"note,omitempty"`
+	// The ID (not Number) of the Issue or Pull Request to associate with this card.
+	// Note and ContentID are mutually exclusive.
+	ContentID int `json:"content_id,omitempty"`
+	// The type of content to associate with this card. Possible values are: "Issue", "PullRequest".
+	ContentType string `json:"content_type,omitempty"`
+}
+
+// CreateProjectCard creates a card in the specified column of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#create-a-project-card
+func (s *RepositoriesService) CreateProjectCard(owner, repo string, columnID int, cardOptions *ProjectCardOptions) (*ProjectCard, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/%v/cards", owner, repo, columnID)
+	req, err := s.client.NewRequest("POST", u, cardOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	card := &ProjectCard{}
+	resp, err := s.client.Do(req, card)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return card, resp, err
+}
+
+// UpdateProjectCard updates a card of a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#update-a-project-card
+func (s *RepositoriesService) UpdateProjectCard(owner, repo string, cardID int, cardOptions *ProjectCardOptions) (*ProjectCard, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/cards/%v", owner, repo, cardID)
+	req, err := s.client.NewRequest("PATCH", u, cardOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	card := &ProjectCard{}
+	resp, err := s.client.Do(req, card)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return card, resp, err
+}
+
+// DeleteProjectCard deletes a card from a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#delete-a-project-card
+func (s *RepositoriesService) DeleteProjectCard(owner, repo string, cardID int) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/cards/%v", owner, repo, cardID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// ProjectCardMoveOptions specifies the parameters to the
+// RepositoriesService.MoveProjectCard method.
+type ProjectCardMoveOptions struct {
+	// Position can be one of "top", "bottom", or "after:<card-id>", where
+	// <card-id> is the ID of a card in the same project.
+	Position string `json:"position"`
+	// ColumnID is the ID of a column in the same project. Note that ColumnID
+	// is required when using Position "after:<card-id>" when that card is in
+	// another column; otherwise it is optional.
+	ColumnID int `json:"column_id,omitempty"`
+}
+
+// MoveProjectCard moves a card within a GitHub Project.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/projects/#move-a-project-card
+func (s *RepositoriesService) MoveProjectCard(owner, repo string, cardID int, moveOptions *ProjectCardMoveOptions) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/projects/columns/cards/%v/moves", owner, repo, cardID)
+	req, err := s.client.NewRequest("POST", u, moveOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeProjectsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_releases.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_releases.go
@@ -1,0 +1,325 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RepositoryRelease represents a GitHub release in a repository.
+type RepositoryRelease struct {
+	ID              *int           `json:"id,omitempty"`
+	TagName         *string        `json:"tag_name,omitempty"`
+	TargetCommitish *string        `json:"target_commitish,omitempty"`
+	Name            *string        `json:"name,omitempty"`
+	Body            *string        `json:"body,omitempty"`
+	Draft           *bool          `json:"draft,omitempty"`
+	Prerelease      *bool          `json:"prerelease,omitempty"`
+	CreatedAt       *Timestamp     `json:"created_at,omitempty"`
+	PublishedAt     *Timestamp     `json:"published_at,omitempty"`
+	URL             *string        `json:"url,omitempty"`
+	HTMLURL         *string        `json:"html_url,omitempty"`
+	AssetsURL       *string        `json:"assets_url,omitempty"`
+	Assets          []ReleaseAsset `json:"assets,omitempty"`
+	UploadURL       *string        `json:"upload_url,omitempty"`
+	ZipballURL      *string        `json:"zipball_url,omitempty"`
+	TarballURL      *string        `json:"tarball_url,omitempty"`
+	Author          *User          `json:"author,omitempty"`
+}
+
+func (r RepositoryRelease) String() string {
+	return Stringify(r)
+}
+
+// ReleaseAsset represents a Github release asset in a repository.
+type ReleaseAsset struct {
+	ID                 *int       `json:"id,omitempty"`
+	URL                *string    `json:"url,omitempty"`
+	Name               *string    `json:"name,omitempty"`
+	Label              *string    `json:"label,omitempty"`
+	State              *string    `json:"state,omitempty"`
+	ContentType        *string    `json:"content_type,omitempty"`
+	Size               *int       `json:"size,omitempty"`
+	DownloadCount      *int       `json:"download_count,omitempty"`
+	CreatedAt          *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt          *Timestamp `json:"updated_at,omitempty"`
+	BrowserDownloadURL *string    `json:"browser_download_url,omitempty"`
+	Uploader           *User      `json:"uploader,omitempty"`
+}
+
+func (r ReleaseAsset) String() string {
+	return Stringify(r)
+}
+
+// ListReleases lists the releases for a repository.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
+func (s *RepositoriesService) ListReleases(owner, repo string, opt *ListOptions) ([]*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	releases := new([]*RepositoryRelease)
+	resp, err := s.client.Do(req, releases)
+	if err != nil {
+		return nil, resp, err
+	}
+	return *releases, resp, err
+}
+
+// GetRelease fetches a single release.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/releases/#get-a-single-release
+func (s *RepositoriesService) GetRelease(owner, repo string, id int) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+	return s.getSingleRelease(u)
+}
+
+// GetLatestRelease fetches the latest published release for the repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-the-latest-release
+func (s *RepositoriesService) GetLatestRelease(owner, repo string) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/latest", owner, repo)
+	return s.getSingleRelease(u)
+}
+
+// GetReleaseByTag fetches a release with the specified tag.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
+func (s *RepositoriesService) GetReleaseByTag(owner, repo, tag string) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	return s.getSingleRelease(u)
+}
+
+func (s *RepositoriesService) getSingleRelease(url string) (*RepositoryRelease, *Response, error) {
+	req, err := s.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	release := new(RepositoryRelease)
+	resp, err := s.client.Do(req, release)
+	if err != nil {
+		return nil, resp, err
+	}
+	return release, resp, err
+}
+
+// CreateRelease adds a new release for a repository.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#create-a-release
+func (s *RepositoriesService) CreateRelease(owner, repo string, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, release)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(RepositoryRelease)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+	return r, resp, err
+}
+
+// EditRelease edits a repository release.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#edit-a-release
+func (s *RepositoriesService) EditRelease(owner, repo string, id int, release *RepositoryRelease) (*RepositoryRelease, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("PATCH", u, release)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(RepositoryRelease)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+	return r, resp, err
+}
+
+// DeleteRelease delete a single release from a repository.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#delete-a-release
+func (s *RepositoriesService) DeleteRelease(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// ListReleaseAssets lists the release's assets.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#list-assets-for-a-release
+func (s *RepositoriesService) ListReleaseAssets(owner, repo string, id int, opt *ListOptions) ([]*ReleaseAsset, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	assets := new([]*ReleaseAsset)
+	resp, err := s.client.Do(req, assets)
+	if err != nil {
+		return nil, resp, nil
+	}
+	return *assets, resp, err
+}
+
+// GetReleaseAsset fetches a single release asset.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+func (s *RepositoriesService) GetReleaseAsset(owner, repo string, id int) (*ReleaseAsset, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asset := new(ReleaseAsset)
+	resp, err := s.client.Do(req, asset)
+	if err != nil {
+		return nil, resp, nil
+	}
+	return asset, resp, err
+}
+
+// DownloadReleaseAsset downloads a release asset or returns a redirect URL.
+//
+// DownloadReleaseAsset returns an io.ReadCloser that reads the contents of the
+// specified release asset. It is the caller's responsibility to close the ReadCloser.
+// If a redirect is returned, the redirect URL will be returned as a string instead
+// of the io.ReadCloser. Exactly one of rc and redirectURL will be zero.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+func (s *RepositoriesService) DownloadReleaseAsset(owner, repo string, id int) (rc io.ReadCloser, redirectURL string, err error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Accept", defaultMediaType)
+
+	s.client.clientMu.Lock()
+	defer s.client.clientMu.Unlock()
+
+	var loc string
+	saveRedirect := s.client.client.CheckRedirect
+	s.client.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		loc = req.URL.String()
+		return errors.New("disable redirect")
+	}
+	defer func() { s.client.client.CheckRedirect = saveRedirect }()
+
+	resp, err := s.client.client.Do(req)
+	if err != nil {
+		if !strings.Contains(err.Error(), "disable redirect") {
+			return nil, "", err
+		}
+		return nil, loc, nil
+	}
+
+	if err := CheckResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, "", err
+	}
+
+	return resp.Body, "", nil
+}
+
+// EditReleaseAsset edits a repository release asset.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#edit-a-release-asset
+func (s *RepositoriesService) EditReleaseAsset(owner, repo string, id int, release *ReleaseAsset) (*ReleaseAsset, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("PATCH", u, release)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asset := new(ReleaseAsset)
+	resp, err := s.client.Do(req, asset)
+	if err != nil {
+		return nil, resp, err
+	}
+	return asset, resp, err
+}
+
+// DeleteReleaseAsset delete a single release asset from a repository.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#delete-a-release-asset
+func (s *RepositoriesService) DeleteReleaseAsset(owner, repo string, id int) (*Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
+// UploadReleaseAsset creates an asset by uploading a file into a release repository.
+// To upload assets that cannot be represented by an os.File, call NewUploadRequest directly.
+//
+// GitHub API docs : http://developer.github.com/v3/repos/releases/#upload-a-release-asset
+func (s *RepositoriesService) UploadReleaseAsset(owner, repo string, id int, opt *UploadOptions, file *os.File) (*ReleaseAsset, *Response, error) {
+	u := fmt.Sprintf("repos/%s/%s/releases/%d/assets", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if stat.IsDir() {
+		return nil, nil, errors.New("the asset to upload can't be a directory")
+	}
+
+	mediaType := mime.TypeByExtension(filepath.Ext(file.Name()))
+	req, err := s.client.NewUploadRequest(u, file, stat.Size(), mediaType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asset := new(ReleaseAsset)
+	resp, err := s.client.Do(req, asset)
+	if err != nil {
+		return nil, resp, err
+	}
+	return asset, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_stats.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_stats.go
@@ -1,0 +1,214 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// ContributorStats represents a contributor to a repository and their
+// weekly contributions to a given repo.
+type ContributorStats struct {
+	Author *Contributor  `json:"author,omitempty"`
+	Total  *int          `json:"total,omitempty"`
+	Weeks  []WeeklyStats `json:"weeks,omitempty"`
+}
+
+func (c ContributorStats) String() string {
+	return Stringify(c)
+}
+
+// WeeklyStats represents the number of additions, deletions and commits
+// a Contributor made in a given week.
+type WeeklyStats struct {
+	Week      *Timestamp `json:"w,omitempty"`
+	Additions *int       `json:"a,omitempty"`
+	Deletions *int       `json:"d,omitempty"`
+	Commits   *int       `json:"c,omitempty"`
+}
+
+func (w WeeklyStats) String() string {
+	return Stringify(w)
+}
+
+// ListContributorsStats gets a repo's contributor list with additions,
+// deletions and commit counts.
+//
+// If this is the first time these statistics are requested for the given
+// repository, this method will return a non-nil error and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing the requested statistics. A follow up request, after a
+// delay of a second or so, should result in a successful request.
+//
+// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#contributors
+func (s *RepositoriesService) ListContributorsStats(owner, repo string) ([]*ContributorStats, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/contributors", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var contributorStats []*ContributorStats
+	resp, err := s.client.Do(req, &contributorStats)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return contributorStats, resp, err
+}
+
+// WeeklyCommitActivity represents the weekly commit activity for a repository.
+// The days array is a group of commits per day, starting on Sunday.
+type WeeklyCommitActivity struct {
+	Days  []int      `json:"days,omitempty"`
+	Total *int       `json:"total,omitempty"`
+	Week  *Timestamp `json:"week,omitempty"`
+}
+
+func (w WeeklyCommitActivity) String() string {
+	return Stringify(w)
+}
+
+// ListCommitActivity returns the last year of commit activity
+// grouped by week. The days array is a group of commits per day,
+// starting on Sunday.
+//
+// If this is the first time these statistics are requested for the given
+// repository, this method will return a non-nil error and a status code of
+// 202. This is because this is the status that github returns to signify that
+// it is now computing the requested statistics. A follow up request, after a
+// delay of a second or so, should result in a successful request.
+//
+// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#commit-activity
+func (s *RepositoriesService) ListCommitActivity(owner, repo string) ([]*WeeklyCommitActivity, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/commit_activity", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var weeklyCommitActivity []*WeeklyCommitActivity
+	resp, err := s.client.Do(req, &weeklyCommitActivity)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return weeklyCommitActivity, resp, err
+}
+
+// ListCodeFrequency returns a weekly aggregate of the number of additions and
+// deletions pushed to a repository.  Returned WeeklyStats will contain
+// additions and deletions, but not total commits.
+//
+// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#code-frequency
+func (s *RepositoriesService) ListCodeFrequency(owner, repo string) ([]*WeeklyStats, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/code_frequency", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var weeks [][]int
+	resp, err := s.client.Do(req, &weeks)
+
+	// convert int slices into WeeklyStats
+	var stats []*WeeklyStats
+	for _, week := range weeks {
+		if len(week) != 3 {
+			continue
+		}
+		stat := &WeeklyStats{
+			Week:      &Timestamp{time.Unix(int64(week[0]), 0)},
+			Additions: Int(week[1]),
+			Deletions: Int(week[2]),
+		}
+		stats = append(stats, stat)
+	}
+
+	return stats, resp, err
+}
+
+// RepositoryParticipation is the number of commits by everyone
+// who has contributed to the repository (including the owner)
+// as well as the number of commits by the owner themself.
+type RepositoryParticipation struct {
+	All   []int `json:"all,omitempty"`
+	Owner []int `json:"owner,omitempty"`
+}
+
+func (r RepositoryParticipation) String() string {
+	return Stringify(r)
+}
+
+// ListParticipation returns the total commit counts for the 'owner'
+// and total commit counts in 'all'. 'all' is everyone combined,
+// including the 'owner' in the last 52 weeks. If you’d like to get
+// the commit counts for non-owners, you can subtract 'all' from 'owner'.
+//
+// The array order is oldest week (index 0) to most recent week.
+//
+// If this is the first time these statistics are requested for the given
+// repository, this method will return a non-nil error and a status code
+// of 202. This is because this is the status that github returns to
+// signify that it is now computing the requested statistics. A follow
+// up request, after a delay of a second or so, should result in a
+// successful request.
+//
+// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#participation
+func (s *RepositoriesService) ListParticipation(owner, repo string) (*RepositoryParticipation, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/participation", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	participation := new(RepositoryParticipation)
+	resp, err := s.client.Do(req, participation)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return participation, resp, err
+}
+
+// PunchCard represents the number of commits made during a given hour of a
+// day of thew eek.
+type PunchCard struct {
+	Day     *int // Day of the week (0-6: =Sunday - Saturday).
+	Hour    *int // Hour of day (0-23).
+	Commits *int // Number of commits.
+}
+
+// ListPunchCard returns the number of commits per hour in each day.
+//
+// GitHub API Docs: https://developer.github.com/v3/repos/statistics/#punch-card
+func (s *RepositoriesService) ListPunchCard(owner, repo string) ([]*PunchCard, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/stats/punch_card", owner, repo)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var results [][]int
+	resp, err := s.client.Do(req, &results)
+
+	// convert int slices into Punchcards
+	var cards []*PunchCard
+	for _, result := range results {
+		if len(result) != 3 {
+			continue
+		}
+		card := &PunchCard{
+			Day:     Int(result[0]),
+			Hour:    Int(result[1]),
+			Commits: Int(result[2]),
+		}
+		cards = append(cards, card)
+	}
+
+	return cards, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_statuses.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_statuses.go
@@ -1,0 +1,128 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// RepoStatus represents the status of a repository at a particular reference.
+type RepoStatus struct {
+	ID  *int    `json:"id,omitempty"`
+	URL *string `json:"url,omitempty"`
+
+	// State is the current state of the repository.  Possible values are:
+	// pending, success, error, or failure.
+	State *string `json:"state,omitempty"`
+
+	// TargetURL is the URL of the page representing this status.  It will be
+	// linked from the GitHub UI to allow users to see the source of the status.
+	TargetURL *string `json:"target_url,omitempty"`
+
+	// Description is a short high level summary of the status.
+	Description *string `json:"description,omitempty"`
+
+	// A string label to differentiate this status from the statuses of other systems.
+	Context *string `json:"context,omitempty"`
+
+	Creator   *User      `json:"creator,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+func (r RepoStatus) String() string {
+	return Stringify(r)
+}
+
+// ListStatuses lists the statuses of a repository at the specified
+// reference.  ref can be a SHA, a branch name, or a tag name.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+func (s *RepositoriesService) ListStatuses(owner, repo, ref string, opt *ListOptions) ([]*RepoStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v/statuses", owner, repo, ref)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statuses := new([]*RepoStatus)
+	resp, err := s.client.Do(req, statuses)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *statuses, resp, err
+}
+
+// CreateStatus creates a new status for a repository at the specified
+// reference.  Ref can be a SHA, a branch name, or a tag name.
+//
+// GitHub API docs: http://developer.github.com/v3/repos/statuses/#create-a-status
+func (s *RepositoriesService) CreateStatus(owner, repo, ref string, status *RepoStatus) (*RepoStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/statuses/%v", owner, repo, ref)
+	req, err := s.client.NewRequest("POST", u, status)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	repoStatus := new(RepoStatus)
+	resp, err := s.client.Do(req, repoStatus)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return repoStatus, resp, err
+}
+
+// CombinedStatus represents the combined status of a repository at a particular reference.
+type CombinedStatus struct {
+	// State is the combined state of the repository.  Possible values are:
+	// failure, pending, or success.
+	State *string `json:"state,omitempty"`
+
+	Name       *string      `json:"name,omitempty"`
+	SHA        *string      `json:"sha,omitempty"`
+	TotalCount *int         `json:"total_count,omitempty"`
+	Statuses   []RepoStatus `json:"statuses,omitempty"`
+
+	CommitURL     *string `json:"commit_url,omitempty"`
+	RepositoryURL *string `json:"repository_url,omitempty"`
+}
+
+func (s CombinedStatus) String() string {
+	return Stringify(s)
+}
+
+// GetCombinedStatus returns the combined status of a repository at the specified
+// reference.  ref can be a SHA, a branch name, or a tag name.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+func (s *RepositoriesService) GetCombinedStatus(owner, repo, ref string, opt *ListOptions) (*CombinedStatus, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v/status", owner, repo, ref)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	status := new(CombinedStatus)
+	resp, err := s.client.Do(req, status)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return status, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_traffic.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/repos_traffic.go
@@ -1,0 +1,173 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// TrafficReferrer represent information about traffic from a referrer .
+type TrafficReferrer struct {
+	Referrer *string `json:"referrer,omitempty"`
+	Count    *int    `json:"count,omitempty"`
+	Uniques  *int    `json:"uniques,omitempty"`
+}
+
+// TrafficPath represent information about the traffic on a path of the repo.
+type TrafficPath struct {
+	Path    *string `json:"path,omitempty"`
+	Title   *string `json:"title,omitempty"`
+	Count   *int    `json:"count,omitempty"`
+	Uniques *int    `json:"uniques,omitempty"`
+}
+
+// TimestampMS represents a timestamp as used in datapoint.
+//
+// It's only used to parse the result given by the API which are unix timestamp in milliseonds.
+type TimestampMS struct {
+	time.Time
+}
+
+// UnmarshalJSON parse unix timestamp.
+func (t *TimestampMS) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	// We can drop the reaminder as returned values are days and it will always be 0
+	*t = TimestampMS{time.Unix(i/1000, 0)}
+	return nil
+}
+
+// TrafficData represent information about a specific timestamp in views or clones list.
+type TrafficData struct {
+	Timestamp *TimestampMS `json:"timestamp,omitempty"`
+	Count     *int         `json:"count,omitempty"`
+	Uniques   *int         `json:"uniques,omitempty"`
+}
+
+// TrafficViews represent information about the number of views in the last 14 days.
+type TrafficViews struct {
+	Views   []*TrafficData `json:"views,omitempty"`
+	Count   *int           `json:"count,omitempty"`
+	Uniques *int           `json:"uniques,omitempty"`
+}
+
+// TrafficClones represent information about the number of clones in the last 14 days.
+type TrafficClones struct {
+	Clones  []*TrafficData `json:"clones,omitempty"`
+	Count   *int           `json:"count,omitempty"`
+	Uniques *int           `json:"uniques,omitempty"`
+}
+
+// TrafficBreakdownOptions specifies the parameters to methods that support breakdown per day or week.
+// Can be one of: day, week. Default: day.
+type TrafficBreakdownOptions struct {
+	Per string `url:"per,omitempty"`
+}
+
+// ListTrafficReferrers list the top 10 referrers over the last 14 days.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/traffic/#list-referrers
+func (s *RepositoriesService) ListTrafficReferrers(owner, repo string) ([]*TrafficReferrer, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/traffic/popular/referrers", owner, repo)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTrafficPreview)
+
+	trafficReferrers := new([]*TrafficReferrer)
+	resp, err := s.client.Do(req, &trafficReferrers)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *trafficReferrers, resp, err
+}
+
+// ListTrafficPaths list the top 10 popular content over the last 14 days.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/traffic/#list-paths
+func (s *RepositoriesService) ListTrafficPaths(owner, repo string) ([]*TrafficPath, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/traffic/popular/paths", owner, repo)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTrafficPreview)
+
+	var paths = new([]*TrafficPath)
+	resp, err := s.client.Do(req, &paths)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *paths, resp, err
+}
+
+// ListTrafficViews get total number of views for the last 14 days and breaks it down either per day or week.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/traffic/#views
+func (s *RepositoriesService) ListTrafficViews(owner, repo string, opt *TrafficBreakdownOptions) (*TrafficViews, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/traffic/views", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTrafficPreview)
+
+	trafficViews := new(TrafficViews)
+	resp, err := s.client.Do(req, &trafficViews)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return trafficViews, resp, err
+}
+
+// ListTrafficClones get total number of clones for the last 14 days and breaks it down either per day or week for the last 14 days.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/traffic/#views
+func (s *RepositoriesService) ListTrafficClones(owner, repo string, opt *TrafficBreakdownOptions) (*TrafficClones, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/traffic/clones", owner, repo)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeTrafficPreview)
+
+	trafficClones := new(TrafficClones)
+	resp, err := s.client.Do(req, &trafficClones)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return trafficClones, resp, err
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/search.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/search.go
@@ -1,0 +1,160 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+
+	qs "github.com/google/go-querystring/query"
+)
+
+// SearchService provides access to the search related functions
+// in the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/search/
+type SearchService service
+
+// SearchOptions specifies optional parameters to the SearchService methods.
+type SearchOptions struct {
+	// How to sort the search results.  Possible values are:
+	//   - for repositories: stars, fork, updated
+	//   - for code: indexed
+	//   - for issues: comments, created, updated
+	//   - for users: followers, repositories, joined
+	//
+	// Default is to sort by best match.
+	Sort string `url:"sort,omitempty"`
+
+	// Sort order if sort parameter is provided. Possible values are: asc,
+	// desc. Default is desc.
+	Order string `url:"order,omitempty"`
+
+	// Whether to retrieve text match metadata with a query
+	TextMatch bool `url:"-"`
+
+	ListOptions
+}
+
+// RepositoriesSearchResult represents the result of a repositories search.
+type RepositoriesSearchResult struct {
+	Total             *int         `json:"total_count,omitempty"`
+	IncompleteResults *bool        `json:"incomplete_results,omitempty"`
+	Repositories      []Repository `json:"items,omitempty"`
+}
+
+// Repositories searches repositories via various criteria.
+//
+// GitHub API docs: http://developer.github.com/v3/search/#search-repositories
+func (s *SearchService) Repositories(query string, opt *SearchOptions) (*RepositoriesSearchResult, *Response, error) {
+	result := new(RepositoriesSearchResult)
+	resp, err := s.search("repositories", query, opt, result)
+	return result, resp, err
+}
+
+// IssuesSearchResult represents the result of an issues search.
+type IssuesSearchResult struct {
+	Total             *int    `json:"total_count,omitempty"`
+	IncompleteResults *bool   `json:"incomplete_results,omitempty"`
+	Issues            []Issue `json:"items,omitempty"`
+}
+
+// Issues searches issues via various criteria.
+//
+// GitHub API docs: http://developer.github.com/v3/search/#search-issues
+func (s *SearchService) Issues(query string, opt *SearchOptions) (*IssuesSearchResult, *Response, error) {
+	result := new(IssuesSearchResult)
+	resp, err := s.search("issues", query, opt, result)
+	return result, resp, err
+}
+
+// UsersSearchResult represents the result of a users search.
+type UsersSearchResult struct {
+	Total             *int   `json:"total_count,omitempty"`
+	IncompleteResults *bool  `json:"incomplete_results,omitempty"`
+	Users             []User `json:"items,omitempty"`
+}
+
+// Users searches users via various criteria.
+//
+// GitHub API docs: http://developer.github.com/v3/search/#search-users
+func (s *SearchService) Users(query string, opt *SearchOptions) (*UsersSearchResult, *Response, error) {
+	result := new(UsersSearchResult)
+	resp, err := s.search("users", query, opt, result)
+	return result, resp, err
+}
+
+// Match represents a single text match.
+type Match struct {
+	Text    *string `json:"text,omitempty"`
+	Indices []int   `json:"indices,omitempty"`
+}
+
+// TextMatch represents a text match for a SearchResult
+type TextMatch struct {
+	ObjectURL  *string `json:"object_url,omitempty"`
+	ObjectType *string `json:"object_type,omitempty"`
+	Property   *string `json:"property,omitempty"`
+	Fragment   *string `json:"fragment,omitempty"`
+	Matches    []Match `json:"matches,omitempty"`
+}
+
+func (tm TextMatch) String() string {
+	return Stringify(tm)
+}
+
+// CodeSearchResult represents the result of a code search.
+type CodeSearchResult struct {
+	Total             *int         `json:"total_count,omitempty"`
+	IncompleteResults *bool        `json:"incomplete_results,omitempty"`
+	CodeResults       []CodeResult `json:"items,omitempty"`
+}
+
+// CodeResult represents a single search result.
+type CodeResult struct {
+	Name        *string     `json:"name,omitempty"`
+	Path        *string     `json:"path,omitempty"`
+	SHA         *string     `json:"sha,omitempty"`
+	HTMLURL     *string     `json:"html_url,omitempty"`
+	Repository  *Repository `json:"repository,omitempty"`
+	TextMatches []TextMatch `json:"text_matches,omitempty"`
+}
+
+func (c CodeResult) String() string {
+	return Stringify(c)
+}
+
+// Code searches code via various criteria.
+//
+// GitHub API docs: http://developer.github.com/v3/search/#search-code
+func (s *SearchService) Code(query string, opt *SearchOptions) (*CodeSearchResult, *Response, error) {
+	result := new(CodeSearchResult)
+	resp, err := s.search("code", query, opt, result)
+	return result, resp, err
+}
+
+// Helper function that executes search queries against different
+// GitHub search types (repositories, code, issues, users)
+func (s *SearchService) search(searchType string, query string, opt *SearchOptions, result interface{}) (*Response, error) {
+	params, err := qs.Values(opt)
+	if err != nil {
+		return nil, err
+	}
+	params.Add("q", query)
+	u := fmt.Sprintf("search/%s?%s", searchType, params.Encode())
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if opt != nil && opt.TextMatch {
+		// Accept header defaults to "application/vnd.github.v3+json"
+		// We change it here to fetch back text-match metadata
+		req.Header.Set("Accept", "application/vnd.github.v3.text-match+json")
+	}
+
+	return s.client.Do(req, result)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/strings.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/strings.go
@@ -1,0 +1,93 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"reflect"
+)
+
+var timestampType = reflect.TypeOf(Timestamp{})
+
+// Stringify attempts to create a reasonable string representation of types in
+// the GitHub library.  It does things like resolve pointers to their values
+// and omits struct fields with nil values.
+func Stringify(message interface{}) string {
+	var buf bytes.Buffer
+	v := reflect.ValueOf(message)
+	stringifyValue(&buf, v)
+	return buf.String()
+}
+
+// stringifyValue was heavily inspired by the goprotobuf library.
+
+func stringifyValue(w io.Writer, val reflect.Value) {
+	if val.Kind() == reflect.Ptr && val.IsNil() {
+		w.Write([]byte("<nil>"))
+		return
+	}
+
+	v := reflect.Indirect(val)
+
+	switch v.Kind() {
+	case reflect.String:
+		fmt.Fprintf(w, `"%s"`, v)
+	case reflect.Slice:
+		w.Write([]byte{'['})
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				w.Write([]byte{' '})
+			}
+
+			stringifyValue(w, v.Index(i))
+		}
+
+		w.Write([]byte{']'})
+		return
+	case reflect.Struct:
+		if v.Type().Name() != "" {
+			w.Write([]byte(v.Type().String()))
+		}
+
+		// special handling of Timestamp values
+		if v.Type() == timestampType {
+			fmt.Fprintf(w, "{%s}", v.Interface())
+			return
+		}
+
+		w.Write([]byte{'{'})
+
+		var sep bool
+		for i := 0; i < v.NumField(); i++ {
+			fv := v.Field(i)
+			if fv.Kind() == reflect.Ptr && fv.IsNil() {
+				continue
+			}
+			if fv.Kind() == reflect.Slice && fv.IsNil() {
+				continue
+			}
+
+			if sep {
+				w.Write([]byte(", "))
+			} else {
+				sep = true
+			}
+
+			w.Write([]byte(v.Type().Field(i).Name))
+			w.Write([]byte{':'})
+			stringifyValue(w, fv)
+		}
+
+		w.Write([]byte{'}'})
+	default:
+		if v.CanInterface() {
+			fmt.Fprint(w, v.Interface())
+		}
+	}
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/timestamp.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/timestamp.go
@@ -1,0 +1,41 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"strconv"
+	"time"
+)
+
+// Timestamp represents a time that can be unmarshalled from a JSON string
+// formatted as either an RFC3339 or Unix timestamp. This is necessary for some
+// fields since the GitHub API is inconsistent in how it represents times. All
+// exported methods of time.Time can be called on Timestamp.
+type Timestamp struct {
+	time.Time
+}
+
+func (t Timestamp) String() string {
+	return t.Time.String()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// Time is expected in RFC3339 or Unix format.
+func (t *Timestamp) UnmarshalJSON(data []byte) (err error) {
+	str := string(data)
+	i, err := strconv.ParseInt(str, 10, 64)
+	if err == nil {
+		(*t).Time = time.Unix(i, 0)
+	} else {
+		(*t).Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
+	}
+	return
+}
+
+// Equal reports whether t and u are equal based on time.Equal
+func (t Timestamp) Equal(u Timestamp) bool {
+	return t.Time.Equal(u.Time)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users.go
@@ -1,0 +1,222 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// UsersService handles communication with the user related
+// methods of the GitHub API.
+//
+// GitHub API docs: http://developer.github.com/v3/users/
+type UsersService service
+
+// User represents a GitHub user.
+type User struct {
+	Login             *string    `json:"login,omitempty"`
+	ID                *int       `json:"id,omitempty"`
+	AvatarURL         *string    `json:"avatar_url,omitempty"`
+	HTMLURL           *string    `json:"html_url,omitempty"`
+	GravatarID        *string    `json:"gravatar_id,omitempty"`
+	Name              *string    `json:"name,omitempty"`
+	Company           *string    `json:"company,omitempty"`
+	Blog              *string    `json:"blog,omitempty"`
+	Location          *string    `json:"location,omitempty"`
+	Email             *string    `json:"email,omitempty"`
+	Hireable          *bool      `json:"hireable,omitempty"`
+	Bio               *string    `json:"bio,omitempty"`
+	PublicRepos       *int       `json:"public_repos,omitempty"`
+	PublicGists       *int       `json:"public_gists,omitempty"`
+	Followers         *int       `json:"followers,omitempty"`
+	Following         *int       `json:"following,omitempty"`
+	CreatedAt         *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt         *Timestamp `json:"updated_at,omitempty"`
+	SuspendedAt       *Timestamp `json:"suspended_at,omitempty"`
+	Type              *string    `json:"type,omitempty"`
+	SiteAdmin         *bool      `json:"site_admin,omitempty"`
+	TotalPrivateRepos *int       `json:"total_private_repos,omitempty"`
+	OwnedPrivateRepos *int       `json:"owned_private_repos,omitempty"`
+	PrivateGists      *int       `json:"private_gists,omitempty"`
+	DiskUsage         *int       `json:"disk_usage,omitempty"`
+	Collaborators     *int       `json:"collaborators,omitempty"`
+	Plan              *Plan      `json:"plan,omitempty"`
+
+	// API URLs
+	URL               *string `json:"url,omitempty"`
+	EventsURL         *string `json:"events_url,omitempty"`
+	FollowingURL      *string `json:"following_url,omitempty"`
+	FollowersURL      *string `json:"followers_url,omitempty"`
+	GistsURL          *string `json:"gists_url,omitempty"`
+	OrganizationsURL  *string `json:"organizations_url,omitempty"`
+	ReceivedEventsURL *string `json:"received_events_url,omitempty"`
+	ReposURL          *string `json:"repos_url,omitempty"`
+	StarredURL        *string `json:"starred_url,omitempty"`
+	SubscriptionsURL  *string `json:"subscriptions_url,omitempty"`
+
+	// TextMatches is only populated from search results that request text matches
+	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
+	TextMatches []TextMatch `json:"text_matches,omitempty"`
+
+	// Permissions identifies the permissions that a user has on a given
+	// repository. This is only populated when calling Repositories.ListCollaborators.
+	Permissions *map[string]bool `json:"permissions,omitempty"`
+}
+
+func (u User) String() string {
+	return Stringify(u)
+}
+
+// Get fetches a user.  Passing the empty string will fetch the authenticated
+// user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/#get-a-single-user
+func (s *UsersService) Get(user string) (*User, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v", user)
+	} else {
+		u = "user"
+	}
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uResp := new(User)
+	resp, err := s.client.Do(req, uResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return uResp, resp, err
+}
+
+// GetByID fetches a user.
+//
+// Note: GetByID uses the undocumented GitHub API endpoint /user/:id.
+func (s *UsersService) GetByID(id int) (*User, *Response, error) {
+	u := fmt.Sprintf("user/%d", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(User)
+	resp, err := s.client.Do(req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
+}
+
+// Edit the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/#update-the-authenticated-user
+func (s *UsersService) Edit(user *User) (*User, *Response, error) {
+	u := "user"
+	req, err := s.client.NewRequest("PATCH", u, user)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uResp := new(User)
+	resp, err := s.client.Do(req, uResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return uResp, resp, err
+}
+
+// UserListOptions specifies optional parameters to the UsersService.ListAll
+// method.
+type UserListOptions struct {
+	// ID of the last user seen
+	Since int `url:"since,omitempty"`
+
+	ListOptions
+}
+
+// ListAll lists all GitHub users.
+//
+// To paginate through all users, populate 'Since' with the ID of the last user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/#get-all-users
+func (s *UsersService) ListAll(opt *UserListOptions) ([]*User, *Response, error) {
+	u, err := addOptions("users", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	users := new([]*User)
+	resp, err := s.client.Do(req, users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *users, resp, err
+}
+
+// ListInvitations lists all currently-open repository invitations for the
+// authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations
+func (s *UsersService) ListInvitations() ([]*RepositoryInvitation, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/repository_invitations", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	invites := []*RepositoryInvitation{}
+	resp, err := s.client.Do(req, &invites)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return invites, resp, err
+}
+
+// AcceptInvitation accepts the currently-open repository invitation for the
+// authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation
+func (s *UsersService) AcceptInvitation(invitationID int) (*Response, error) {
+	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
+	req, err := s.client.NewRequest("PATCH", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	return s.client.Do(req, nil)
+}
+
+// DeclineInvitation declines the currently-open repository invitation for the
+// authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation
+func (s *UsersService) DeclineInvitation(invitationID int) (*Response, error) {
+	u := fmt.Sprintf("user/repository_invitations/%v", invitationID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryInvitationsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_administration.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_administration.go
@@ -1,0 +1,64 @@
+// Copyright 2014 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// PromoteSiteAdmin promotes a user to a site administrator of a GitHub Enterprise instance.
+//
+// GitHub API docs: https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+func (s *UsersService) PromoteSiteAdmin(user string) (*Response, error) {
+	u := fmt.Sprintf("users/%v/site_admin", user)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DemoteSiteAdmin demotes a user from site administrator of a GitHub Enterprise instance.
+//
+// GitHub API docs: https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+func (s *UsersService) DemoteSiteAdmin(user string) (*Response, error) {
+	u := fmt.Sprintf("users/%v/site_admin", user)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Suspend a user on a GitHub Enterprise instance.
+//
+// GitHub API docs: https://developer.github.com/v3/users/administration/#suspend-a-user
+func (s *UsersService) Suspend(user string) (*Response, error) {
+	u := fmt.Sprintf("users/%v/suspended", user)
+
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Unsuspend a user on a GitHub Enterprise instance.
+//
+// GitHub API docs: https://developer.github.com/v3/users/administration/#unsuspend-a-user
+func (s *UsersService) Unsuspend(user string) (*Response, error) {
+	u := fmt.Sprintf("users/%v/suspended", user)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_emails.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_emails.go
@@ -1,0 +1,69 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+// UserEmail represents user's email address
+type UserEmail struct {
+	Email    *string `json:"email,omitempty"`
+	Primary  *bool   `json:"primary,omitempty"`
+	Verified *bool   `json:"verified,omitempty"`
+}
+
+// ListEmails lists all email addresses for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+func (s *UsersService) ListEmails(opt *ListOptions) ([]*UserEmail, *Response, error) {
+	u := "user/emails"
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	emails := new([]*UserEmail)
+	resp, err := s.client.Do(req, emails)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *emails, resp, err
+}
+
+// AddEmails adds email addresses of the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/emails/#add-email-addresses
+func (s *UsersService) AddEmails(emails []string) ([]*UserEmail, *Response, error) {
+	u := "user/emails"
+	req, err := s.client.NewRequest("POST", u, emails)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	e := new([]*UserEmail)
+	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *e, resp, err
+}
+
+// DeleteEmails deletes email addresses from authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/emails/#delete-email-addresses
+func (s *UsersService) DeleteEmails(emails []string) (*Response, error) {
+	u := "user/emails"
+	req, err := s.client.NewRequest("DELETE", u, emails)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_followers.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_followers.go
@@ -1,0 +1,116 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ListFollowers lists the followers for a user.  Passing the empty string will
+// fetch followers for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/followers/#list-followers-of-a-user
+func (s *UsersService) ListFollowers(user string, opt *ListOptions) ([]*User, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/followers", user)
+	} else {
+		u = "user/followers"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	users := new([]*User)
+	resp, err := s.client.Do(req, users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *users, resp, err
+}
+
+// ListFollowing lists the people that a user is following.  Passing the empty
+// string will list people the authenticated user is following.
+//
+// GitHub API docs: http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
+func (s *UsersService) ListFollowing(user string, opt *ListOptions) ([]*User, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/following", user)
+	} else {
+		u = "user/following"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	users := new([]*User)
+	resp, err := s.client.Do(req, users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *users, resp, err
+}
+
+// IsFollowing checks if "user" is following "target".  Passing the empty
+// string for "user" will check if the authenticated user is following "target".
+//
+// GitHub API docs: http://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user
+func (s *UsersService) IsFollowing(user, target string) (bool, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/following/%v", user, target)
+	} else {
+		u = fmt.Sprintf("user/following/%v", target)
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	following, err := parseBoolResponse(err)
+	return following, resp, err
+}
+
+// Follow will cause the authenticated user to follow the specified user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/followers/#follow-a-user
+func (s *UsersService) Follow(user string) (*Response, error) {
+	u := fmt.Sprintf("user/following/%v", user)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Unfollow will cause the authenticated user to unfollow the specified user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/followers/#unfollow-a-user
+func (s *UsersService) Unfollow(user string) (*Response, error) {
+	u := fmt.Sprintf("user/following/%v", user)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_gpg_keys.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_gpg_keys.go
@@ -1,0 +1,127 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// GPGKey represents a GitHub user's public GPG key used to verify GPG signed commits and tags.
+//
+// https://developer.github.com/changes/2016-04-04-git-signing-api-preview/
+type GPGKey struct {
+	ID                *int       `json:"id,omitempty"`
+	PrimaryKeyID      *int       `json:"primary_key_id,omitempty"`
+	KeyID             *string    `json:"key_id,omitempty"`
+	PublicKey         *string    `json:"public_key,omitempty"`
+	Emails            []GPGEmail `json:"emails,omitempty"`
+	Subkeys           []GPGKey   `json:"subkeys,omitempty"`
+	CanSign           *bool      `json:"can_sign,omitempty"`
+	CanEncryptComms   *bool      `json:"can_encrypt_comms,omitempty"`
+	CanEncryptStorage *bool      `json:"can_encrypt_storage,omitempty"`
+	CanCertify        *bool      `json:"can_certify,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+}
+
+// String stringifies a GPGKey.
+func (k GPGKey) String() string {
+	return Stringify(k)
+}
+
+// GPGEmail represents an email address associated to a GPG key.
+type GPGEmail struct {
+	Email    *string `json:"email,omitempty"`
+	Verified *bool   `json:"verified,omitempty"`
+}
+
+// ListGPGKeys lists the current user's GPG keys. It requires authentication
+// via Basic Auth or via OAuth with at least read:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys
+func (s *UsersService) ListGPGKeys() ([]*GPGKey, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/gpg_keys", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	var keys []*GPGKey
+	resp, err := s.client.Do(req, &keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return keys, resp, err
+}
+
+// GetGPGKey gets extended details for a single GPG key. It requires authentication
+// via Basic Auth or via OAuth with at least read:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key
+func (s *UsersService) GetGPGKey(id int) (*GPGKey, *Response, error) {
+	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	key := &GPGKey{}
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// CreateGPGKey creates a GPG key. It requires authenticatation via Basic Auth
+// or OAuth with at least write:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key
+func (s *UsersService) CreateGPGKey(armoredPublicKey string) (*GPGKey, *Response, error) {
+	gpgKey := &struct {
+		ArmoredPublicKey string `json:"armored_public_key"`
+	}{ArmoredPublicKey: armoredPublicKey}
+	req, err := s.client.NewRequest("POST", "user/gpg_keys", gpgKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	key := &GPGKey{}
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// DeleteGPGKey deletes a GPG key. It requires authentication via Basic Auth or
+// via OAuth with at least admin:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key
+func (s *UsersService) DeleteGPGKey(id int) (*Response, error) {
+	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_keys.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-github/github/users_keys.go
@@ -1,0 +1,105 @@
+// Copyright 2013 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// Key represents a public SSH key used to authenticate a user or deploy script.
+type Key struct {
+	ID       *int    `json:"id,omitempty"`
+	Key      *string `json:"key,omitempty"`
+	URL      *string `json:"url,omitempty"`
+	Title    *string `json:"title,omitempty"`
+	ReadOnly *bool   `json:"read_only,omitempty"`
+}
+
+func (k Key) String() string {
+	return Stringify(k)
+}
+
+// ListKeys lists the verified public keys for a user.  Passing the empty
+// string will fetch keys for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+func (s *UsersService) ListKeys(user string, opt *ListOptions) ([]*Key, *Response, error) {
+	var u string
+	if user != "" {
+		u = fmt.Sprintf("users/%v/keys", user)
+	} else {
+		u = "user/keys"
+	}
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keys := new([]*Key)
+	resp, err := s.client.Do(req, keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *keys, resp, err
+}
+
+// GetKey fetches a single public key.
+//
+// GitHub API docs: http://developer.github.com/v3/users/keys/#get-a-single-public-key
+func (s *UsersService) GetKey(id int) (*Key, *Response, error) {
+	u := fmt.Sprintf("user/keys/%v", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key := new(Key)
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// CreateKey adds a public key for the authenticated user.
+//
+// GitHub API docs: http://developer.github.com/v3/users/keys/#create-a-public-key
+func (s *UsersService) CreateKey(key *Key) (*Key, *Response, error) {
+	u := "user/keys"
+
+	req, err := s.client.NewRequest("POST", u, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k := new(Key)
+	resp, err := s.client.Do(req, k)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return k, resp, err
+}
+
+// DeleteKey deletes a public key.
+//
+// GitHub API docs: http://developer.github.com/v3/users/keys/#delete-a-public-key
+func (s *UsersService) DeleteKey(id int) (*Response, error) {
+	u := fmt.Sprintf("user/keys/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/cmd/sync-github-release/vendor/github.com/google/go-querystring/LICENSE
+++ b/cmd/sync-github-release/vendor/github.com/google/go-querystring/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Google. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/sync-github-release/vendor/github.com/google/go-querystring/query/encode.go
+++ b/cmd/sync-github-release/vendor/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,320 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string. Including
+// the "semicolon" option will encode the value as a semicolon-delimited string.
+// Including the "brackets" option signals that the multiple URL values should
+// have "[]" appended to the value name. "numbered" will append a number to
+// the end of each incidence of the value name, example:
+// name0=value0&name1=value1, etc.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs are encoded including parent fields in value names for
+// scoping. e.g:
+//
+// 	"user[name]=acme&user[addr][postcode]=1234&user[addr][city]=SFO"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	values := make(url.Values)
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if v == nil {
+		return values, nil
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("semicolon") {
+				del = ';'
+			} else if opts.Contains("brackets") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/net/AUTHORS
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/cmd/sync-github-release/vendor/golang.org/x/net/CONTRIBUTORS
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/cmd/sync-github-release/vendor/golang.org/x/net/LICENSE
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/sync-github-release/vendor/golang.org/x/net/PATENTS
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/cmd/sync-github-release/vendor/golang.org/x/net/context/context.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/context/context.go
@@ -1,0 +1,156 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package context defines the Context type, which carries deadlines,
+// cancelation signals, and other request-scoped values across API boundaries
+// and between processes.
+//
+// Incoming requests to a server should create a Context, and outgoing calls to
+// servers should accept a Context. The chain of function calls between must
+// propagate the Context, optionally replacing it with a modified copy created
+// using WithDeadline, WithTimeout, WithCancel, or WithValue.
+//
+// Programs that use Contexts should follow these rules to keep interfaces
+// consistent across packages and enable static analysis tools to check context
+// propagation:
+//
+// Do not store Contexts inside a struct type; instead, pass a Context
+// explicitly to each function that needs it. The Context should be the first
+// parameter, typically named ctx:
+//
+// 	func DoSomething(ctx context.Context, arg Arg) error {
+// 		// ... use ctx ...
+// 	}
+//
+// Do not pass a nil Context, even if a function permits it. Pass context.TODO
+// if you are unsure about which Context to use.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+//
+// The same Context may be passed to functions running in different goroutines;
+// Contexts are safe for simultaneous use by multiple goroutines.
+//
+// See http://blog.golang.org/context for example code for a server that uses
+// Contexts.
+package context
+
+import "time"
+
+// A Context carries a deadline, a cancelation signal, and other values across
+// API boundaries.
+//
+// Context's methods may be called by multiple goroutines simultaneously.
+type Context interface {
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled. Deadline returns ok==false when no deadline is
+	// set. Successive calls to Deadline return the same results.
+	Deadline() (deadline time.Time, ok bool)
+
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled. Done may return nil if this context can
+	// never be canceled. Successive calls to Done return the same value.
+	//
+	// WithCancel arranges for Done to be closed when cancel is called;
+	// WithDeadline arranges for Done to be closed when the deadline
+	// expires; WithTimeout arranges for Done to be closed when the timeout
+	// elapses.
+	//
+	// Done is provided for use in select statements:
+	//
+	//  // Stream generates values with DoSomething and sends them to out
+	//  // until DoSomething returns an error or ctx.Done is closed.
+	//  func Stream(ctx context.Context, out chan<- Value) error {
+	//  	for {
+	//  		v, err := DoSomething(ctx)
+	//  		if err != nil {
+	//  			return err
+	//  		}
+	//  		select {
+	//  		case <-ctx.Done():
+	//  			return ctx.Err()
+	//  		case out <- v:
+	//  		}
+	//  	}
+	//  }
+	//
+	// See http://blog.golang.org/pipelines for more examples of how to use
+	// a Done channel for cancelation.
+	Done() <-chan struct{}
+
+	// Err returns a non-nil error value after Done is closed. Err returns
+	// Canceled if the context was canceled or DeadlineExceeded if the
+	// context's deadline passed. No other values for Err are defined.
+	// After Done is closed, successive calls to Err return the same value.
+	Err() error
+
+	// Value returns the value associated with this context for key, or nil
+	// if no value is associated with key. Successive calls to Value with
+	// the same key returns the same result.
+	//
+	// Use context values only for request-scoped data that transits
+	// processes and API boundaries, not for passing optional parameters to
+	// functions.
+	//
+	// A key identifies a specific value in a Context. Functions that wish
+	// to store values in Context typically allocate a key in a global
+	// variable then use that key as the argument to context.WithValue and
+	// Context.Value. A key can be any type that supports equality;
+	// packages should define keys as an unexported type to avoid
+	// collisions.
+	//
+	// Packages that define a Context key should provide type-safe accessors
+	// for the values stores using that key:
+	//
+	// 	// Package user defines a User type that's stored in Contexts.
+	// 	package user
+	//
+	// 	import "golang.org/x/net/context"
+	//
+	// 	// User is the type of value stored in the Contexts.
+	// 	type User struct {...}
+	//
+	// 	// key is an unexported type for keys defined in this package.
+	// 	// This prevents collisions with keys defined in other packages.
+	// 	type key int
+	//
+	// 	// userKey is the key for user.User values in Contexts. It is
+	// 	// unexported; clients use user.NewContext and user.FromContext
+	// 	// instead of using this key directly.
+	// 	var userKey key = 0
+	//
+	// 	// NewContext returns a new Context that carries value u.
+	// 	func NewContext(ctx context.Context, u *User) context.Context {
+	// 		return context.WithValue(ctx, userKey, u)
+	// 	}
+	//
+	// 	// FromContext returns the User value stored in ctx, if any.
+	// 	func FromContext(ctx context.Context) (*User, bool) {
+	// 		u, ok := ctx.Value(userKey).(*User)
+	// 		return u, ok
+	// 	}
+	Value(key interface{}) interface{}
+}
+
+// Background returns a non-nil, empty Context. It is never canceled, has no
+// values, and has no deadline. It is typically used by the main function,
+// initialization, and tests, and as the top-level Context for incoming
+// requests.
+func Background() Context {
+	return background
+}
+
+// TODO returns a non-nil, empty Context. Code should use context.TODO when
+// it's unclear which Context to use or it is not yet available (because the
+// surrounding function has not yet been extended to accept a Context
+// parameter).  TODO is recognized by static analysis tools that determine
+// whether Contexts are propagated correctly in a program.
+func TODO() Context {
+	return todo
+}
+
+// A CancelFunc tells an operation to abandon its work.
+// A CancelFunc does not wait for the work to stop.
+// After the first call, subsequent calls to a CancelFunc do nothing.
+type CancelFunc func()

--- a/cmd/sync-github-release/vendor/golang.org/x/net/context/go17.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/context/go17.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package context
+
+import (
+	"context" // standard library's context, as of Go 1.7
+	"time"
+)
+
+var (
+	todo       = context.TODO()
+	background = context.Background()
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = context.Canceled
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = context.DeadlineExceeded
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	ctx, f := context.WithCancel(parent)
+	return ctx, CancelFunc(f)
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d. If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent. The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	ctx, f := context.WithDeadline(parent, deadline)
+	return ctx, CancelFunc(f)
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return context.WithValue(parent, key, val)
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/net/context/pre_go17.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/net/context/pre_go17.go
@@ -1,0 +1,300 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package context
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// An emptyCtx is never canceled, has no values, and has no deadline. It is not
+// struct{}, since vars of this type must have distinct addresses.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	switch e {
+	case background:
+		return "context.Background"
+	case todo:
+		return "context.TODO"
+	}
+	return "unknown empty Context"
+}
+
+var (
+	background = new(emptyCtx)
+	todo       = new(emptyCtx)
+)
+
+// Canceled is the error returned by Context.Err when the context is canceled.
+var Canceled = errors.New("context canceled")
+
+// DeadlineExceeded is the error returned by Context.Err when the context's
+// deadline passes.
+var DeadlineExceeded = errors.New("context deadline exceeded")
+
+// WithCancel returns a copy of parent with a new Done channel. The returned
+// context's Done channel is closed when the returned cancel function is called
+// or when the parent context's Done channel is closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
+	c := newCancelCtx(parent)
+	propagateCancel(parent, c)
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// newCancelCtx returns an initialized cancelCtx.
+func newCancelCtx(parent Context) *cancelCtx {
+	return &cancelCtx{
+		Context: parent,
+		done:    make(chan struct{}),
+	}
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent Context, child canceler) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	if p, ok := parentCancelCtx(parent); ok {
+		p.mu.Lock()
+		if p.err != nil {
+			// parent has already been canceled
+			child.cancel(false, p.err)
+		} else {
+			if p.children == nil {
+				p.children = make(map[canceler]bool)
+			}
+			p.children[child] = true
+		}
+		p.mu.Unlock()
+	} else {
+		go func() {
+			select {
+			case <-parent.Done():
+				child.cancel(false, parent.Err())
+			case <-child.Done():
+			}
+		}()
+	}
+}
+
+// parentCancelCtx follows a chain of parent references until it finds a
+// *cancelCtx. This function understands how each of the concrete types in this
+// package represents its parent.
+func parentCancelCtx(parent Context) (*cancelCtx, bool) {
+	for {
+		switch c := parent.(type) {
+		case *cancelCtx:
+			return c, true
+		case *timerCtx:
+			return c.cancelCtx, true
+		case *valueCtx:
+			parent = c.Context
+		default:
+			return nil, false
+		}
+	}
+}
+
+// removeChild removes a context from its parent.
+func removeChild(parent Context, child canceler) {
+	p, ok := parentCancelCtx(parent)
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	if p.children != nil {
+		delete(p.children, child)
+	}
+	p.mu.Unlock()
+}
+
+// A canceler is a context type that can be canceled directly. The
+// implementations are *cancelCtx and *timerCtx.
+type canceler interface {
+	cancel(removeFromParent bool, err error)
+	Done() <-chan struct{}
+}
+
+// A cancelCtx can be canceled. When canceled, it also cancels any children
+// that implement canceler.
+type cancelCtx struct {
+	Context
+
+	done chan struct{} // closed by the first cancel call.
+
+	mu       sync.Mutex
+	children map[canceler]bool // set to nil by the first cancel call
+	err      error             // set to non-nil by the first cancel call
+}
+
+func (c *cancelCtx) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *cancelCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *cancelCtx) String() string {
+	return fmt.Sprintf("%v.WithCancel", c.Context)
+}
+
+// cancel closes c.done, cancels each of c's children, and, if
+// removeFromParent is true, removes c from its parent's children.
+func (c *cancelCtx) cancel(removeFromParent bool, err error) {
+	if err == nil {
+		panic("context: internal error: missing cancel error")
+	}
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	for child := range c.children {
+		// NOTE: acquiring the child's lock while holding parent's lock.
+		child.cancel(false, err)
+	}
+	c.children = nil
+	c.mu.Unlock()
+
+	if removeFromParent {
+		removeChild(c.Context, c)
+	}
+}
+
+// WithDeadline returns a copy of the parent context with the deadline adjusted
+// to be no later than d. If the parent's deadline is already earlier than d,
+// WithDeadline(parent, d) is semantically equivalent to parent. The returned
+// context's Done channel is closed when the deadline expires, when the returned
+// cancel function is called, or when the parent context's Done channel is
+// closed, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete.
+func WithDeadline(parent Context, deadline time.Time) (Context, CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return WithCancel(parent)
+	}
+	c := &timerCtx{
+		cancelCtx: newCancelCtx(parent),
+		deadline:  deadline,
+	}
+	propagateCancel(parent, c)
+	d := deadline.Sub(time.Now())
+	if d <= 0 {
+		c.cancel(true, DeadlineExceeded) // deadline has already passed
+		return c, func() { c.cancel(true, Canceled) }
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err == nil {
+		c.timer = time.AfterFunc(d, func() {
+			c.cancel(true, DeadlineExceeded)
+		})
+	}
+	return c, func() { c.cancel(true, Canceled) }
+}
+
+// A timerCtx carries a timer and a deadline. It embeds a cancelCtx to
+// implement Done and Err. It implements cancel by stopping its timer then
+// delegating to cancelCtx.cancel.
+type timerCtx struct {
+	*cancelCtx
+	timer *time.Timer // Under cancelCtx.mu.
+
+	deadline time.Time
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) {
+	return c.deadline, true
+}
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("%v.WithDeadline(%s [%s])", c.cancelCtx.Context, c.deadline, c.deadline.Sub(time.Now()))
+}
+
+func (c *timerCtx) cancel(removeFromParent bool, err error) {
+	c.cancelCtx.cancel(false, err)
+	if removeFromParent {
+		// Remove this timerCtx from its parent cancelCtx's children.
+		removeChild(c.cancelCtx.Context, c)
+	}
+	c.mu.Lock()
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.mu.Unlock()
+}
+
+// WithTimeout returns WithDeadline(parent, time.Now().Add(timeout)).
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this Context complete:
+//
+// 	func slowOperationWithTimeout(ctx context.Context) (Result, error) {
+// 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+// 		defer cancel()  // releases resources if slowOperation completes before timeout elapses
+// 		return slowOperation(ctx)
+// 	}
+func WithTimeout(parent Context, timeout time.Duration) (Context, CancelFunc) {
+	return WithDeadline(parent, time.Now().Add(timeout))
+}
+
+// WithValue returns a copy of parent in which the value associated with key is
+// val.
+//
+// Use context Values only for request-scoped data that transits processes and
+// APIs, not for passing optional parameters to functions.
+func WithValue(parent Context, key interface{}, val interface{}) Context {
+	return &valueCtx{parent, key, val}
+}
+
+// A valueCtx carries a key-value pair. It implements Value for that key and
+// delegates all other calls to the embedded Context.
+type valueCtx struct {
+	Context
+	key, val interface{}
+}
+
+func (c *valueCtx) String() string {
+	return fmt.Sprintf("%v.WithValue(%#v, %#v)", c.Context, c.key, c.val)
+}
+
+func (c *valueCtx) Value(key interface{}) interface{} {
+	if c.key == key {
+		return c.val
+	}
+	return c.Context.Value(key)
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/.travis.yml
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - tip
+
+install:
+  - export GOPATH="$HOME/gopath"
+  - mkdir -p "$GOPATH/src/golang.org/x"
+  - mv "$TRAVIS_BUILD_DIR" "$GOPATH/src/golang.org/x/oauth2"
+  - go get -v -t -d golang.org/x/oauth2/...
+
+script:
+  - go test -v golang.org/x/oauth2/...

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/AUTHORS
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/CONTRIBUTING.md
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Go
+
+Go is an open source project.
+
+It is the work of hundreds of contributors. We appreciate your help!
+
+
+## Filing issues
+
+When [filing an issue](https://github.com/golang/oauth2/issues), make sure to answer these five questions:
+
+1. What version of Go are you using (`go version`)?
+2. What operating system and processor architecture are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+General questions should go to the [golang-nuts mailing list](https://groups.google.com/group/golang-nuts) instead of the issue tracker.
+The gophers there will answer or ask you to file an issue if you've tripped over a bug.
+
+## Contributing code
+
+Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html)
+before sending patches.
+
+**We do not accept GitHub pull requests**
+(we use [Gerrit](https://code.google.com/p/gerrit/) instead for code review).
+
+Unless otherwise noted, the Go source files are distributed under
+the BSD-style license found in the LICENSE file.
+

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/CONTRIBUTORS
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/LICENSE
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The oauth2 Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/README.md
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/README.md
@@ -1,0 +1,65 @@
+# OAuth2 for Go
+
+[![Build Status](https://travis-ci.org/golang/oauth2.svg?branch=master)](https://travis-ci.org/golang/oauth2)
+[![GoDoc](https://godoc.org/golang.org/x/oauth2?status.svg)](https://godoc.org/golang.org/x/oauth2)
+
+oauth2 package contains a client implementation for OAuth 2.0 spec.
+
+## Installation
+
+~~~~
+go get golang.org/x/oauth2
+~~~~
+
+See godoc for further documentation and examples.
+
+* [godoc.org/golang.org/x/oauth2](http://godoc.org/golang.org/x/oauth2)
+* [godoc.org/golang.org/x/oauth2/google](http://godoc.org/golang.org/x/oauth2/google)
+
+
+## App Engine
+
+In change 96e89be (March 2015) we removed the `oauth2.Context2` type in favor
+of the [`context.Context`](https://golang.org/x/net/context#Context) type from
+the `golang.org/x/net/context` package
+
+This means its no longer possible to use the "Classic App Engine"
+`appengine.Context` type with the `oauth2` package. (You're using
+Classic App Engine if you import the package `"appengine"`.)
+
+To work around this, you may use the new `"google.golang.org/appengine"`
+package. This package has almost the same API as the `"appengine"` package,
+but it can be fetched with `go get` and used on "Managed VMs" and well as
+Classic App Engine.
+
+See the [new `appengine` package's readme](https://github.com/golang/appengine#updating-a-go-app-engine-app)
+for information on updating your app.
+
+If you don't want to update your entire app to use the new App Engine packages,
+you may use both sets of packages in parallel, using only the new packages
+with the `oauth2` package.
+
+	import (
+		"golang.org/x/net/context"
+		"golang.org/x/oauth2"
+		"golang.org/x/oauth2/google"
+		newappengine "google.golang.org/appengine"
+		newurlfetch "google.golang.org/appengine/urlfetch"
+
+		"appengine"
+	)
+
+	func handler(w http.ResponseWriter, r *http.Request) {
+		var c appengine.Context = appengine.NewContext(r)
+		c.Infof("Logging a message with the old package")
+
+		var ctx context.Context = newappengine.NewContext(r)
+		client := &http.Client{
+			Transport: &oauth2.Transport{
+				Source: google.AppEngineTokenSource(ctx, "scope"),
+				Base:   &newurlfetch.Transport{Context: ctx},
+			},
+		}
+		client.Get("...")
+	}
+

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/client_appengine.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/client_appengine.go
@@ -1,0 +1,25 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+// App Engine hooks.
+
+package oauth2
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func init() {
+	internal.RegisterContextClientFunc(contextClientAppEngine)
+}
+
+func contextClientAppEngine(ctx context.Context) (*http.Client, error) {
+	return urlfetch.Client(ctx), nil
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -1,0 +1,76 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"bufio"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseKey converts the binary contents of a private key file
+// to an *rsa.PrivateKey. It detects whether the private key is in a
+// PEM container or not. If so, it extracts the the private key
+// from PEM container before conversion. It only supports PEM
+// containers with no passphrase.
+func ParseKey(key []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(key)
+	if block != nil {
+		key = block.Bytes
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(key)
+	if err != nil {
+		parsedKey, err = x509.ParsePKCS1PrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("private key should be a PEM or plain PKSC1 or PKCS8; parse error: %v", err)
+		}
+	}
+	parsed, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key is invalid")
+	}
+	return parsed, nil
+}
+
+func ParseINI(ini io.Reader) (map[string]map[string]string, error) {
+	result := map[string]map[string]string{
+		"": map[string]string{}, // root section
+	}
+	scanner := bufio.NewScanner(ini)
+	currentSection := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, ";") {
+			// comment.
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = strings.TrimSpace(line[1 : len(line)-1])
+			result[currentSection] = map[string]string{}
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && parts[0] != "" {
+			result[currentSection][strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning ini: %v", err)
+	}
+	return result, nil
+}
+
+func CondVal(v string) []string {
+	if v == "" {
+		return nil
+	}
+	return []string{v}
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/token.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/token.go
@@ -1,0 +1,225 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// This type is a mirror of oauth2.Token and exists to break
+// an otherwise-circular dependency. Other internal packages
+// should convert this Token into an oauth2.Token before use.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time
+
+	// Raw optionally contains extra metadata from the server
+	// when updating a token.
+	Raw interface{}
+}
+
+// tokenJSON is the struct representing the HTTP response from OAuth2
+// providers returning a token in JSON form.
+type tokenJSON struct {
+	AccessToken  string         `json:"access_token"`
+	TokenType    string         `json:"token_type"`
+	RefreshToken string         `json:"refresh_token"`
+	ExpiresIn    expirationTime `json:"expires_in"` // at least PayPal returns string, while most return number
+	Expires      expirationTime `json:"expires"`    // broken Facebook spelling of expires_in
+}
+
+func (e *tokenJSON) expiry() (t time.Time) {
+	if v := e.ExpiresIn; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	if v := e.Expires; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	return
+}
+
+type expirationTime int32
+
+func (e *expirationTime) UnmarshalJSON(b []byte) error {
+	var n json.Number
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*e = expirationTime(i)
+	return nil
+}
+
+var brokenAuthHeaderProviders = []string{
+	"https://accounts.google.com/",
+	"https://api.dropbox.com/",
+	"https://api.dropboxapi.com/",
+	"https://api.instagram.com/",
+	"https://api.netatmo.net/",
+	"https://api.odnoklassniki.ru/",
+	"https://api.pushbullet.com/",
+	"https://api.soundcloud.com/",
+	"https://api.twitch.tv/",
+	"https://app.box.com/",
+	"https://connect.stripe.com/",
+	"https://login.microsoftonline.com/",
+	"https://login.salesforce.com/",
+	"https://oauth.sandbox.trainingpeaks.com/",
+	"https://oauth.trainingpeaks.com/",
+	"https://oauth.vk.com/",
+	"https://openapi.baidu.com/",
+	"https://slack.com/",
+	"https://test-sandbox.auth.corp.google.com",
+	"https://test.salesforce.com/",
+	"https://user.gini.net/",
+	"https://www.douban.com/",
+	"https://www.googleapis.com/",
+	"https://www.linkedin.com/",
+	"https://www.strava.com/oauth/",
+	"https://www.wunderlist.com/oauth/",
+	"https://api.patreon.com/",
+}
+
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	brokenAuthHeaderProviders = append(brokenAuthHeaderProviders, tokenURL)
+}
+
+// providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL
+// implements the OAuth2 spec correctly
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+// In summary:
+// - Reddit only accepts client secret in the Authorization header
+// - Dropbox accepts either it in URL param or Auth header, but not both.
+// - Google only accepts URL param (not spec compliant?), not Auth header
+// - Stripe only accepts client secret in Auth header with Bearer method, not Basic
+func providerAuthHeaderWorks(tokenURL string) bool {
+	for _, s := range brokenAuthHeaderProviders {
+		if strings.HasPrefix(tokenURL, s) {
+			// Some sites fail to implement the OAuth2 spec fully.
+			return false
+		}
+	}
+
+	// Assume the provider implements the spec properly
+	// otherwise. We can add more exceptions as they're
+	// discovered. We will _not_ be adding configurable hooks
+	// to this package to let users select server bugs.
+	return true
+}
+
+func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values) (*Token, error) {
+	hc, err := ContextClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	v.Set("client_id", clientID)
+	bustedAuth := !providerAuthHeaderWorks(tokenURL)
+	if bustedAuth && clientSecret != "" {
+		v.Set("client_secret", clientSecret)
+	}
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if !bustedAuth {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+	r, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+	}
+	if code := r.StatusCode; code < 200 || code > 299 {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v\nResponse: %s", r.Status, body)
+	}
+
+	var token *Token
+	content, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	switch content {
+	case "application/x-www-form-urlencoded", "text/plain":
+		vals, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  vals.Get("access_token"),
+			TokenType:    vals.Get("token_type"),
+			RefreshToken: vals.Get("refresh_token"),
+			Raw:          vals,
+		}
+		e := vals.Get("expires_in")
+		if e == "" {
+			// TODO(jbd): Facebook's OAuth2 implementation is broken and
+			// returns expires_in field in expires. Remove the fallback to expires,
+			// when Facebook fixes their implementation.
+			e = vals.Get("expires")
+		}
+		expires, _ := strconv.Atoi(e)
+		if expires != 0 {
+			token.Expiry = time.Now().Add(time.Duration(expires) * time.Second)
+		}
+	default:
+		var tj tokenJSON
+		if err = json.Unmarshal(body, &tj); err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  tj.AccessToken,
+			TokenType:    tj.TokenType,
+			RefreshToken: tj.RefreshToken,
+			Expiry:       tj.expiry(),
+			Raw:          make(map[string]interface{}),
+		}
+		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
+	}
+	// Don't overwrite `RefreshToken` with an empty value
+	// if this was a token refreshing request.
+	if token.RefreshToken == "" {
+		token.RefreshToken = v.Get("refresh_token")
+	}
+	return token, nil
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/transport.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/internal/transport.go
@@ -1,0 +1,69 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient ContextKey
+
+// ContextKey is just an empty struct. It exists so HTTPClient can be
+// an immutable public variable with a unique type. It's immutable
+// because nobody else can create a ContextKey, being unexported.
+type ContextKey struct{}
+
+// ContextClientFunc is a func which tries to return an *http.Client
+// given a Context value. If it returns an error, the search stops
+// with that error.  If it returns (nil, nil), the search continues
+// down the list of registered funcs.
+type ContextClientFunc func(context.Context) (*http.Client, error)
+
+var contextClientFuncs []ContextClientFunc
+
+func RegisterContextClientFunc(fn ContextClientFunc) {
+	contextClientFuncs = append(contextClientFuncs, fn)
+}
+
+func ContextClient(ctx context.Context) (*http.Client, error) {
+	if ctx != nil {
+		if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
+			return hc, nil
+		}
+	}
+	for _, fn := range contextClientFuncs {
+		c, err := fn(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
+			return c, nil
+		}
+	}
+	return http.DefaultClient, nil
+}
+
+func ContextTransport(ctx context.Context) http.RoundTripper {
+	hc, err := ContextClient(ctx)
+	// This is a rare error case (somebody using nil on App Engine).
+	if err != nil {
+		return ErrorTransport{err}
+	}
+	return hc.Transport
+}
+
+// ErrorTransport returns the specified error on RoundTrip.
+// This RoundTripper should be used in rare error cases where
+// error handling can be postponed to response handling time.
+type ErrorTransport struct{ Err error }
+
+func (t ErrorTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.Err
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/oauth2.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/oauth2.go
@@ -1,0 +1,341 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package oauth2 provides support for making
+// OAuth2 authorized and authenticated HTTP requests.
+// It can additionally grant authorization with Bearer JWT.
+package oauth2
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// NoContext is the default context you should supply if not using
+// your own context.Context (see https://golang.org/x/net/context).
+//
+// Deprecated: Use context.Background() or context.TODO() instead.
+var NoContext = context.TODO()
+
+// RegisterBrokenAuthHeaderProvider registers an OAuth2 server
+// identified by the tokenURL prefix as an OAuth2 implementation
+// which doesn't support the HTTP Basic authentication
+// scheme to authenticate with the authorization server.
+// Once a server is registered, credentials (client_id and client_secret)
+// will be passed as query parameters rather than being present
+// in the Authorization header.
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	internal.RegisterBrokenAuthHeaderProvider(tokenURL)
+}
+
+// Config describes a typical 3-legged OAuth2 flow, with both the
+// client application information and the server's endpoint URLs.
+// For the client credentials 2-legged OAuth2 flow, see the clientcredentials
+// package (https://golang.org/x/oauth2/clientcredentials).
+type Config struct {
+	// ClientID is the application's ID.
+	ClientID string
+
+	// ClientSecret is the application's secret.
+	ClientSecret string
+
+	// Endpoint contains the resource server's token endpoint
+	// URLs. These are constants specific to each server and are
+	// often available via site-specific packages, such as
+	// google.Endpoint or github.Endpoint.
+	Endpoint Endpoint
+
+	// RedirectURL is the URL to redirect users going through
+	// the OAuth flow, after the resource owner's URLs.
+	RedirectURL string
+
+	// Scope specifies optional requested permissions.
+	Scopes []string
+}
+
+// A TokenSource is anything that can return a token.
+type TokenSource interface {
+	// Token returns a token or an error.
+	// Token must be safe for concurrent use by multiple goroutines.
+	// The returned Token must not be modified.
+	Token() (*Token, error)
+}
+
+// Endpoint contains the OAuth 2.0 provider's authorization and token
+// endpoint URLs.
+type Endpoint struct {
+	AuthURL  string
+	TokenURL string
+}
+
+var (
+	// AccessTypeOnline and AccessTypeOffline are options passed
+	// to the Options.AuthCodeURL method. They modify the
+	// "access_type" field that gets sent in the URL returned by
+	// AuthCodeURL.
+	//
+	// Online is the default if neither is specified. If your
+	// application needs to refresh access tokens when the user
+	// is not present at the browser, then use offline. This will
+	// result in your application obtaining a refresh token the
+	// first time your application exchanges an authorization
+	// code for a user.
+	AccessTypeOnline  AuthCodeOption = SetAuthURLParam("access_type", "online")
+	AccessTypeOffline AuthCodeOption = SetAuthURLParam("access_type", "offline")
+
+	// ApprovalForce forces the users to view the consent dialog
+	// and confirm the permissions request at the URL returned
+	// from AuthCodeURL, even if they've already done so.
+	ApprovalForce AuthCodeOption = SetAuthURLParam("approval_prompt", "force")
+)
+
+// An AuthCodeOption is passed to Config.AuthCodeURL.
+type AuthCodeOption interface {
+	setValue(url.Values)
+}
+
+type setParam struct{ k, v string }
+
+func (p setParam) setValue(m url.Values) { m.Set(p.k, p.v) }
+
+// SetAuthURLParam builds an AuthCodeOption which passes key/value parameters
+// to a provider's authorization endpoint.
+func SetAuthURLParam(key, value string) AuthCodeOption {
+	return setParam{key, value}
+}
+
+// AuthCodeURL returns a URL to OAuth 2.0 provider's consent page
+// that asks for permissions for the required scopes explicitly.
+//
+// State is a token to protect the user from CSRF attacks. You must
+// always provide a non-zero string and validate that it matches the
+// the state query parameter on your redirect callback.
+// See http://tools.ietf.org/html/rfc6749#section-10.12 for more info.
+//
+// Opts may include AccessTypeOnline or AccessTypeOffline, as well
+// as ApprovalForce.
+func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
+	var buf bytes.Buffer
+	buf.WriteString(c.Endpoint.AuthURL)
+	v := url.Values{
+		"response_type": {"code"},
+		"client_id":     {c.ClientID},
+		"redirect_uri":  internal.CondVal(c.RedirectURL),
+		"scope":         internal.CondVal(strings.Join(c.Scopes, " ")),
+		"state":         internal.CondVal(state),
+	}
+	for _, opt := range opts {
+		opt.setValue(v)
+	}
+	if strings.Contains(c.Endpoint.AuthURL, "?") {
+		buf.WriteByte('&')
+	} else {
+		buf.WriteByte('?')
+	}
+	buf.WriteString(v.Encode())
+	return buf.String()
+}
+
+// PasswordCredentialsToken converts a resource owner username and password
+// pair into a token.
+//
+// Per the RFC, this grant type should only be used "when there is a high
+// degree of trust between the resource owner and the client (e.g., the client
+// is part of the device operating system or a highly privileged application),
+// and when other authorization grant types are not available."
+// See https://tools.ietf.org/html/rfc6749#section-4.3 for more info.
+//
+// The HTTP client to use is derived from the context.
+// If nil, http.DefaultClient is used.
+func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type": {"password"},
+		"username":   {username},
+		"password":   {password},
+		"scope":      internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Exchange converts an authorization code into a token.
+//
+// It is used after a resource provider redirects the user back
+// to the Redirect URI (the URL obtained from AuthCodeURL).
+//
+// The HTTP client to use is derived from the context.
+// If a client is not provided via the context, http.DefaultClient is used.
+//
+// The code will be in the *http.Request.FormValue("code"). Before
+// calling Exchange, be sure to validate FormValue("state").
+func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": internal.CondVal(c.RedirectURL),
+		"scope":        internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Client returns an HTTP client using the provided token.
+// The token will auto-refresh as necessary. The underlying
+// HTTP transport will be obtained using the provided context.
+// The returned client and its Transport should not be modified.
+func (c *Config) Client(ctx context.Context, t *Token) *http.Client {
+	return NewClient(ctx, c.TokenSource(ctx, t))
+}
+
+// TokenSource returns a TokenSource that returns t until t expires,
+// automatically refreshing it as necessary using the provided context.
+//
+// Most users will use Config.Client instead.
+func (c *Config) TokenSource(ctx context.Context, t *Token) TokenSource {
+	tkr := &tokenRefresher{
+		ctx:  ctx,
+		conf: c,
+	}
+	if t != nil {
+		tkr.refreshToken = t.RefreshToken
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: tkr,
+	}
+}
+
+// tokenRefresher is a TokenSource that makes "grant_type"=="refresh_token"
+// HTTP requests to renew a token using a RefreshToken.
+type tokenRefresher struct {
+	ctx          context.Context // used to get HTTP requests
+	conf         *Config
+	refreshToken string
+}
+
+// WARNING: Token is not safe for concurrent access, as it
+// updates the tokenRefresher's refreshToken field.
+// Within this package, it is used by reuseTokenSource which
+// synchronizes calls to this method with its own mutex.
+func (tf *tokenRefresher) Token() (*Token, error) {
+	if tf.refreshToken == "" {
+		return nil, errors.New("oauth2: token expired and refresh token is not set")
+	}
+
+	tk, err := retrieveToken(tf.ctx, tf.conf, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tf.refreshToken},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if tf.refreshToken != tk.RefreshToken {
+		tf.refreshToken = tk.RefreshToken
+	}
+	return tk, err
+}
+
+// reuseTokenSource is a TokenSource that holds a single token in memory
+// and validates its expiry before each call to retrieve it with
+// Token. If it's expired, it will be auto-refreshed using the
+// new TokenSource.
+type reuseTokenSource struct {
+	new TokenSource // called when t is expired.
+
+	mu sync.Mutex // guards t
+	t  *Token
+}
+
+// Token returns the current token if it's still valid, else will
+// refresh the current token (using r.Context for HTTP client
+// information) and return the new one.
+func (s *reuseTokenSource) Token() (*Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.t.Valid() {
+		return s.t, nil
+	}
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.t = t
+	return t, nil
+}
+
+// StaticTokenSource returns a TokenSource that always returns the same token.
+// Because the provided token t is never refreshed, StaticTokenSource is only
+// useful for tokens that never expire.
+func StaticTokenSource(t *Token) TokenSource {
+	return staticTokenSource{t}
+}
+
+// staticTokenSource is a TokenSource that always returns the same Token.
+type staticTokenSource struct {
+	t *Token
+}
+
+func (s staticTokenSource) Token() (*Token, error) {
+	return s.t, nil
+}
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient internal.ContextKey
+
+// NewClient creates an *http.Client from a Context and TokenSource.
+// The returned client is not valid beyond the lifetime of the context.
+//
+// As a special case, if src is nil, a non-OAuth2 client is returned
+// using the provided context. This exists to support related OAuth2
+// packages.
+func NewClient(ctx context.Context, src TokenSource) *http.Client {
+	if src == nil {
+		c, err := internal.ContextClient(ctx)
+		if err != nil {
+			return &http.Client{Transport: internal.ErrorTransport{Err: err}}
+		}
+		return c
+	}
+	return &http.Client{
+		Transport: &Transport{
+			Base:   internal.ContextTransport(ctx),
+			Source: ReuseTokenSource(nil, src),
+		},
+	}
+}
+
+// ReuseTokenSource returns a TokenSource which repeatedly returns the
+// same token as long as it's valid, starting with t.
+// When its cached token is invalid, a new token is obtained from src.
+//
+// ReuseTokenSource is typically used to reuse tokens from a cache
+// (such as a file on disk) between runs of a program, rather than
+// obtaining new tokens unnecessarily.
+//
+// The initial token t may be nil, in which case the TokenSource is
+// wrapped in a caching version if it isn't one already. This also
+// means it's always safe to wrap ReuseTokenSource around any other
+// TokenSource without adverse effects.
+func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
+	// Don't wrap a reuseTokenSource in itself. That would work,
+	// but cause an unnecessary number of mutex operations.
+	// Just build the equivalent one.
+	if rt, ok := src.(*reuseTokenSource); ok {
+		if t == nil {
+			// Just use it directly.
+			return rt
+		}
+		src = rt.new
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: src,
+	}
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/token.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/token.go
@@ -1,0 +1,158 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// expiryDelta determines how earlier a token should be considered
+// expired than its actual expiration time. It is used to avoid late
+// expirations due to client-server time mismatches.
+const expiryDelta = 10 * time.Second
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// Most users of this package should not access fields of Token
+// directly. They're exported mostly for use by related packages
+// implementing derivative OAuth2 flows.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string `json:"access_token"`
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string `json:"token_type,omitempty"`
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time `json:"expiry,omitempty"`
+
+	// raw optionally contains extra metadata from the server
+	// when updating a token.
+	raw interface{}
+}
+
+// Type returns t.TokenType if non-empty, else "Bearer".
+func (t *Token) Type() string {
+	if strings.EqualFold(t.TokenType, "bearer") {
+		return "Bearer"
+	}
+	if strings.EqualFold(t.TokenType, "mac") {
+		return "MAC"
+	}
+	if strings.EqualFold(t.TokenType, "basic") {
+		return "Basic"
+	}
+	if t.TokenType != "" {
+		return t.TokenType
+	}
+	return "Bearer"
+}
+
+// SetAuthHeader sets the Authorization header to r using the access
+// token in t.
+//
+// This method is unnecessary when using Transport or an HTTP Client
+// returned by this package.
+func (t *Token) SetAuthHeader(r *http.Request) {
+	r.Header.Set("Authorization", t.Type()+" "+t.AccessToken)
+}
+
+// WithExtra returns a new Token that's a clone of t, but using the
+// provided raw extra map. This is only intended for use by packages
+// implementing derivative OAuth2 flows.
+func (t *Token) WithExtra(extra interface{}) *Token {
+	t2 := new(Token)
+	*t2 = *t
+	t2.raw = extra
+	return t2
+}
+
+// Extra returns an extra field.
+// Extra fields are key-value pairs returned by the server as a
+// part of the token retrieval response.
+func (t *Token) Extra(key string) interface{} {
+	if raw, ok := t.raw.(map[string]interface{}); ok {
+		return raw[key]
+	}
+
+	vals, ok := t.raw.(url.Values)
+	if !ok {
+		return nil
+	}
+
+	v := vals.Get(key)
+	switch s := strings.TrimSpace(v); strings.Count(s, ".") {
+	case 0: // Contains no "."; try to parse as int
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	case 1: // Contains a single "."; try to parse as float
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	}
+
+	return v
+}
+
+// expired reports whether the token is expired.
+// t must be non-nil.
+func (t *Token) expired() bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return t.Expiry.Add(-expiryDelta).Before(time.Now())
+}
+
+// Valid reports whether t is non-nil, has an AccessToken, and is not expired.
+func (t *Token) Valid() bool {
+	return t != nil && t.AccessToken != "" && !t.expired()
+}
+
+// tokenFromInternal maps an *internal.Token struct into
+// a *Token struct.
+func tokenFromInternal(t *internal.Token) *Token {
+	if t == nil {
+		return nil
+	}
+	return &Token{
+		AccessToken:  t.AccessToken,
+		TokenType:    t.TokenType,
+		RefreshToken: t.RefreshToken,
+		Expiry:       t.Expiry,
+		raw:          t.Raw,
+	}
+}
+
+// retrieveToken takes a *Config and uses that to retrieve an *internal.Token.
+// This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
+// with an error..
+func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
+	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v)
+	if err != nil {
+		return nil, err
+	}
+	return tokenFromInternal(tk), nil
+}

--- a/cmd/sync-github-release/vendor/golang.org/x/oauth2/transport.go
+++ b/cmd/sync-github-release/vendor/golang.org/x/oauth2/transport.go
@@ -1,0 +1,132 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// Transport is an http.RoundTripper that makes OAuth 2.0 HTTP requests,
+// wrapping a base RoundTripper and adding an Authorization header
+// with a token from the supplied Sources.
+//
+// Transport is a low-level mechanism. Most code will use the
+// higher-level Config.Client method instead.
+type Transport struct {
+	// Source supplies the token to add to outgoing requests'
+	// Authorization headers.
+	Source TokenSource
+
+	// Base is the base RoundTripper used to make HTTP requests.
+	// If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+
+	mu     sync.Mutex                      // guards modReq
+	modReq map[*http.Request]*http.Request // original -> modified
+}
+
+// RoundTrip authorizes and authenticates the request with an
+// access token. If no token exists or token is expired,
+// tries to refresh/fetch a new token.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Source == nil {
+		return nil, errors.New("oauth2: Transport's Source is nil")
+	}
+	token, err := t.Source.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	req2 := cloneRequest(req) // per RoundTripper contract
+	token.SetAuthHeader(req2)
+	t.setModReq(req, req2)
+	res, err := t.base().RoundTrip(req2)
+	if err != nil {
+		t.setModReq(req, nil)
+		return nil, err
+	}
+	res.Body = &onEOFReader{
+		rc: res.Body,
+		fn: func() { t.setModReq(req, nil) },
+	}
+	return res, nil
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		t.mu.Lock()
+		modReq := t.modReq[req]
+		delete(t.modReq, req)
+		t.mu.Unlock()
+		cr.CancelRequest(modReq)
+	}
+}
+
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+func (t *Transport) setModReq(orig, mod *http.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.modReq == nil {
+		t.modReq = make(map[*http.Request]*http.Request)
+	}
+	if mod == nil {
+		delete(t.modReq, orig)
+	} else {
+		t.modReq[orig] = mod
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}
+
+type onEOFReader struct {
+	rc io.ReadCloser
+	fn func()
+}
+
+func (r *onEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *onEOFReader) Close() error {
+	err := r.rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *onEOFReader) runFunc() {
+	if fn := r.fn; fn != nil {
+		fn()
+		r.fn = nil
+	}
+}


### PR DESCRIPTION
sync-github-releases currently fails to build because the `github.com/google/go-github/github` package has changed. this PR vendors a working version of the dependencies so that it builds.