### PR TITLE
Support revision as well as issue number

### DIFF
--- a/cmd/github-comment/main.go
+++ b/cmd/github-comment/main.go
@@ -1,11 +1,17 @@
 /*
-Command 'github-comment' comments on GitHub pull request.
+Command 'github-comment' comments on GitHub issues/revision.
 
-  $ github-comment ORG REPO NUMBER COMMENT
+  $ github-comment ORG REPO NUMBER|REVISION COMMENT
 
 For example, if you want to comment on https://github.com/tcnksm/ghr pull request number 987
 
   $ github-comment tcnksm ghr 987 "This is test comment"
+
+If you want to do on https://github.com/tcnksm/ghr/commit/5e0f14a4236b60e9c59aa3523cd7dac60e1859e8
+
+  $ github-comment tcnksm ghr 5e0f14a "This is test comment too"
+
+If you comment on a revision, hash must be 7 or more chars
 
 To use this command, you need to prepare GitHub API Token and set it via GITHUB_TOKEN
 env var.
@@ -33,7 +39,7 @@ const EnvToken = "GITHUB_TOKEN"
 func main() {
 
 	if len(os.Args) < 5 {
-		log.Fatal("[Usage] github-comment ORG REPO NUMBER BODY")
+		log.Fatal("[Usage] github-comment ORG REPO NUMBER|REVISION BODY")
 	}
 
 	token := os.Getenv(EnvToken)
@@ -41,16 +47,21 @@ func main() {
 		log.Fatal("You need GitHub API token via GITHUB_TOKEN env var")
 	}
 
-	owner, repo := os.Args[1], os.Args[2]
-	issueNumber, err := strconv.Atoi(os.Args[3])
-	if err != nil {
-		log.Fatalf("[ERROR] Issue number must be int: %e", err)
+	var (
+		issueNumber int
+		err         error
+	)
+	owner, repo, revision := os.Args[1], os.Args[2], os.Args[3]
+
+	isRevision := isValidRevision(revision)
+	if !isRevision {
+		issueNumber, err = strconv.Atoi(revision)
+		if err != nil {
+			log.Fatalf("[ERROR] Issue number must be int: %e", err)
+		}
 	}
 
 	body := strings.Join(os.Args[4:], " ")
-	log.Printf("[INFO] Create a comment %q on https://github.com/%s/%s/issues/%d",
-		body, owner, repo, issueNumber,
-	)
 
 	// Construct github HTTP client
 	ts := oauth2.StaticTokenSource(&oauth2.Token{
@@ -71,11 +82,40 @@ func main() {
 		}
 	}
 
-	if _, _, err := client.Issues.CreateComment(context.Background(), owner, repo, issueNumber, &github.IssueComment{
-		Body: &body,
-	}); err != nil {
+	if isRevision {
+		log.Printf("[INFO] Creating a comment %q on https://github.com/%s/%s/commit/%s",
+			body, owner, repo, revision,
+		)
+		_, _, err = client.Repositories.CreateComment(
+			context.Background(),
+			owner,
+			repo,
+			revision,
+			&github.RepositoryComment{Body: &body},
+		)
+	} else {
+		log.Printf("[INFO] Creating a comment %q on https://github.com/%s/%s/issues/%d",
+			body, owner, repo, issueNumber,
+		)
+		_, _, err = client.Issues.CreateComment(
+			context.Background(),
+			owner,
+			repo,
+			issueNumber,
+			&github.IssueComment{Body: &body},
+		)
+	}
+	if err != nil {
 		log.Fatalf("[ERROR] Failed to create comment: %s", err)
 	}
 
 	log.Printf("[INFO] Successfully created a comment!")
+}
+
+func isValidRevision(arg string) bool {
+	// In GitHub, 7 chars word is used as a short hash
+	if len(arg) >= 7 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## WHAT

I'd like to comment on a revision as well as an issue number. Like the following:

```console
$ ./github-comment b4b4r07 misc 123 "test commet 1"
2018/03/08 18:39:49 [INFO] Creating a comment "test commet 1" on https://github.com/b4b4r07/misc/issues/123
2018/03/08 18:39:49 [INFO] Successfully created a comment!

$ ./github-comment b4b4r07 misc 80a037e "test commet 2"
2018/03/08 18:40:33 [INFO] Creating a comment "test commet 2" on https://github.com/b4b4r07/misc/commit/80a037e
2018/03/08 18:40:34 [INFO] Successfully created a comment!
```

## WHY

On GitHub, we can comment on a revision:

![2018-03-08 18 46 08](https://user-images.githubusercontent.com/4442708/37144327-02d47d98-2301-11e8-82d9-869dbc7cbdbe.png)

