### PR TITLE
Add new command `github-app-authenticate`

### DIFF
--- a/cmd/github-app-authenticate/main.go
+++ b/cmd/github-app-authenticate/main.go
@@ -1,0 +1,61 @@
+/*
+Command 'github-app-authenticate' authenticates Github App by private keys and prints installation access token
+
+  $ github-app-authenticate INTEGRATION_ID INSTALLATION_ID GITHUB_RSA_PRIVATE_KEY_PEM_PATH
+
+To install, use go get,
+
+  $ go get github.com/tcnksm/misc/cmd/github-app-authenticate
+
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/bradleyfalzon/ghinstallation"
+)
+
+func main() {
+	if len(os.Args) != 4 {
+		log.Fatal("[Usage] github-app-authenticate INTEGRATION_ID INSTALLATION_ID GITHUB_RSA_PRIVATE_KEY_PEM_PATH")
+	}
+
+	var (
+		appIntegrationID  int
+		appInstallationID int
+
+		err error
+	)
+	appIntegrationIDstr, appInstallationIDstr, rsaPrivateKeyPemPath := os.Args[1], os.Args[2], os.Args[3]
+
+	appIntegrationID, err = strconv.Atoi(appIntegrationIDstr)
+	if err != nil {
+		log.Fatalf("[ERROR] INTEGRATION ID must be number: %s", err)
+	}
+
+	appInstallationID, err = strconv.Atoi(appInstallationIDstr)
+	if err != nil {
+		log.Fatalf("[ERROR] INSTALLATION ID must be number: %s", err)
+	}
+
+	itr, err := ghinstallation.NewKeyFromFile(
+		http.DefaultTransport,
+		appIntegrationID,
+		appInstallationID,
+		rsaPrivateKeyPemPath,
+	)
+	if err != nil {
+		log.Fatalf("[ERRRO] Failed to create new trasport: %s\n", err)
+	}
+
+	token, err := itr.Token()
+	if err != nil {
+		log.Fatalf("[ERRRO] Failed to get token: %s\n", err)
+	}
+	fmt.Printf("%s", token)
+}


### PR DESCRIPTION
The command `github-app-authenticate` authenticates Github Apps by a private key and prints installation access token. 

Normally, Github tools like [`github-comment`](https://github.com/tcnksm/misc/tree/master/cmd/github-comment) require the Github token. If it's ok to use personal Github token, you can use these tool but sometimes you want to use bot account for it. Instead of creating a bot account for each use case, it's better to use Github App. But to be Github App, you need to modify your code. This simple command helps this gap. It generates token with Github App installation. So you can use the existing tool with Github App. 

For example, 

```bash
export GITHUB_TOKEN=$(github-app-authenticate 123 456 tcnksm-misc.private-key.pem); github-comment tcnksm misc 1234
```